### PR TITLE
Added: 'resources' command to list all the supported resources from AWS

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -19,9 +19,11 @@ var (
 	tags []string
 
 	awsCmd = &cobra.Command{
-		Use:   "aws",
-		Short: "Terracognita reads from AWS and generates TF",
-		Long:  "Terracognita reads from AWS and generates TF",
+		Use:      "aws",
+		Short:    "Terracognita reads from AWS and generates hcl resources and/or terraform state",
+		Long:     "Terracognita reads from AWS and generates hcl resources and/or terraform state",
+		PreRunE:  preRunEOutput,
+		PostRunE: postRunEOutput,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate required flags
 			if err := requiredStringFlags("access-key", "secret-key", "region"); err != nil {
@@ -72,6 +74,7 @@ var (
 )
 
 func init() {
+	awsCmd.AddCommand(awsResourcesCmd)
 
 	// Required flags
 

--- a/cmd/aws_resources.go
+++ b/cmd/aws_resources.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/cycloidio/terracognita/aws"
+	"github.com/spf13/cobra"
+)
+
+var (
+	awsResourcesCmd = &cobra.Command{
+		Use:   "resources",
+		Short: "List of all the AWS supported Resources",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, r := range aws.ResourceTypeStrings() {
+				fmt.Println(r)
+			}
+		},
+	}
+)


### PR DESCRIPTION
It lists all the supported resources from `aws`.

Also moved the logic for `preRun` and `postRun` to `aws` as it was validating that the flags `--hcl` or `--tfstate` where defined.