### PR TITLE
Added: Subcommand 'version'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+terracognita
 
 # Created by https://www.gitignore.io/api/go,vim,linux,emacs,windows,visualstudio,visualstudiocode,osx
 # Edit at https://www.gitignore.io/?templates=go,vim,linux,emacs,windows,visualstudio,visualstudiocode,osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The `version` subcommand to show the actual build version
+  ([Issue #24](https://github.com/cycloidio/terracognita/issues/24))
+
 ### Fixed
 
 - Error with the Import Filter not validating before Importing/Reading

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+RUN GIT_TAG=$(git describe --tags --always) && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/cycloidio/terracognita/cmd.Version=$GIT_TAG"
 
 # final stage
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 GOLINT := $(BIN_DIR)/golint
 MOCKGEN := $(BIN_DIR)/mockgen
 
+VERSION= $(shell git describe --tags --always)
+
+# Setup the -ldflags option for go build here, interpolate the variable values
+LDFLAGS=-ldflags "-X github.com/cycloidio/terracognita/cmd.Version=${VERSION}"
+
 .PHONY: help
 help: Makefile ## This help dialog
 	@IFS=$$'\n' ; \
@@ -55,7 +60,7 @@ dbuild: ## Builds the docker image with same name as the binary
 
 .PHONY: build
 build: ## Builds the binary
-	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 go build -o $(BIN)
+	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 go build -o $(BIN) ${LDFLAGS}
 
 .PHONY: clean
 clean: ## Removes binary and/or docker image

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ func postRunEOutput(cmd *cobra.Command, args []string) error {
 func init() {
 	cobra.OnInitialize(initViper)
 	RootCmd.AddCommand(awsCmd)
+	RootCmd.AddCommand(versionCmd)
 
 	RootCmd.PersistentFlags().String("hcl", "", "HCL output file")
 	_ = viper.BindPFlag("hcl", RootCmd.PersistentFlags().Lookup("hcl"))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version is the value of the current verion, this
+	// is set via -ldflags
+	Version string
+
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Prints the current build version",
+		Run: func(cmd *cobra.Command, args []string) {
+			if Version != "" {
+				fmt.Printf("The current version is: %s\n", Version)
+			} else {
+				fmt.Printf("No version defined\n")
+			}
+		},
+	}
+)


### PR DESCRIPTION
It adds the subcommand `version`. It fetches the version in build time (`make build` or `docker build`).

Example of the output:

```bash
~/.../github.com/cycloidio/terracognita [fg-24] $> ./terracognita version
The current version is: v0.1.5-8-g8504b09
```

The version it's basically https://git-scm.com/docs/git-describe#_examples which is:

```
v1.0.4-14-g2414721

i.e. the current head of my "parent" branch is based on v1.0.4, but since it has a few commits on top of that,
describe has added the number of additional commits ("14") and an abbreviated object name for the commit itself ("2414721") at the end.

The number of additional commits is the number of commits which would be displayed by "git log v1.0.4..parent".
The hash suffix is "-g" + unambiguous abbreviation for the tip commit of parent
```

OFC I can change how it's displayed by parsing the actual version and getting the `Version: 0.1.5` `Commit/Revision: 8504b09` it depends on what you want :smile: 


Closes #24 