### PR TITLE
Updated: 'raws' to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Error with the Import Filter not validating before Importing/Reading
   ([PR #22](https://github.com/cycloidio/terracognita/pull/22))
+- Update to version 1.0.1 of `raws` to fix panic on importing `aws_s3_bucket`
+  ([Issue #29](https://github.com/cycloidio/terracognita/issues/29))

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cycloidio/terracognita
 require (
 	github.com/aws/aws-sdk-go v1.19.47
 	github.com/chr4/pwgen v1.1.0
-	github.com/cycloidio/raws v1.0.0
+	github.com/cycloidio/raws v1.0.1
 	github.com/golang/mock v1.2.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cycloidio/raws v1.0.0 h1:Sy5h+meu6y6k85eInantamuZfJUmLDJImR5tkAreKEM=
 github.com/cycloidio/raws v1.0.0/go.mod h1:cVgpisA66wxryE3KiRnIOcM0VDQ/nVqu68z9k+nByos=
+github.com/cycloidio/raws v1.0.1 h1:hh3Yl5YKo3r2tumgcPeAyygp+MomDY3aa4+15+74ttg=
+github.com/cycloidio/raws v1.0.1/go.mod h1:cVgpisA66wxryE3KiRnIOcM0VDQ/nVqu68z9k+nByos=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
The new version of `raws` includes a fix for the issue.

Closes #29 