### PR TITLE
Added: '-verbose' and '-vverbose' flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,7 +197,6 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
-[Ll]og/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `version` subcommand to show the actual build version
   ([Issue #24](https://github.com/cycloidio/terracognita/issues/24))
 - CI/CD pipeline
+  ([Issue #31](https://github.com/cycloidio/terracognita/pull/34))
+- The `-verbose` and `-debug` options
+  ([Issue #17](https://github.com/cycloidio/terracognita/issues/17))
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(MOCKGEN):
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) $(GOLINT) ## Runs the linter
-	@GO111MODULE=on golangci-lint run -E goimports ./... && golint -set_exit_status ./...
+	@GO111MODULE=on golangci-lint run -D errcheck -E goimports ./... && golint -set_exit_status ./...
 
 .PHONY: generate
 generate: $(MOCKGEN) ## Generates the needed code

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -84,8 +84,5 @@ func (a *aws) Region() string { return a.awsr.GetRegions()[0] }
 func (a *aws) TagKey() string { return "tags" }
 func (a *aws) HasResourceType(t string) bool {
 	_, err := ResourceTypeString(t)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cycloidio/raws"
 	"github.com/cycloidio/terracognita/cache"
 	"github.com/cycloidio/terracognita/filter"
+	"github.com/cycloidio/terracognita/log"
 	"github.com/cycloidio/terracognita/provider"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
@@ -24,6 +25,7 @@ type aws struct {
 
 // NewProvider returns an AWS Provider
 func NewProvider(ctx context.Context, accessKey, secretKey, region string) (provider.Provider, error) {
+	log.Get().Log("func", "aws.NewProvider", "msg", "configuring raws Reader")
 	awsr, err := raws.NewAWSReader(ctx, accessKey, secretKey, []string{region}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize 'raws' because: %s", err)
@@ -35,6 +37,7 @@ func NewProvider(ctx context.Context, accessKey, secretKey, region string) (prov
 		Region:    region,
 	}
 
+	log.Get().Log("func", "aws.NewProvider", "msg", "configuring TF Client")
 	awsClient, err := cfg.Client()
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize 'terraform/aws.Config.Client()' because: %s", err)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,6 +1,10 @@
 package filter
 
-import "github.com/cycloidio/terracognita/tag"
+import (
+	"fmt"
+
+	"github.com/cycloidio/terracognita/tag"
+)
 
 // Filter is the list of all possible
 // filters that can be used to filter
@@ -25,6 +29,15 @@ func (f *Filter) IsExcluded(v string) bool {
 
 	_, ok := f.exclude[v]
 	return ok
+}
+
+// String returns an stringification of the Filter
+func (f *Filter) String() string {
+	return fmt.Sprintf(`
+	Tags:    %s,
+	Include: %s,
+	Exclude: %s,
+`, f.Tags, f.Include, f.Exclude)
 }
 
 // calculateExludeMap makes a map of the Exclude so

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ require (
 	github.com/aws/aws-sdk-go v1.19.47
 	github.com/chr4/pwgen v1.1.0
 	github.com/cycloidio/raws v1.0.1
+	github.com/go-kit/kit v0.9.0
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/golang/mock v1.2.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,7 +108,11 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-critic/go-critic v0.0.0-20181204210945-ee9bf5809ead/go.mod h1:3MzXZKJdeXqdU9cj+rvZdNiN7SZ8V9OjybF8loZDmHU=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
+github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -281,6 +285,7 @@ github.com/keybase/go-crypto v0.0.0-20181127160227-255a5089e85a/go.mod h1:ghbZsc
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"sync"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/hashicorp/terraform/helper/logging"
+)
+
+var logger kitlog.Logger
+var once sync.Once
+
+// Init initializes the log, it can only be called once,
+// repetitive calls to it will not change it.
+// It also set the level of vebosity of the
+// Terraform logs via tflogs, if true it'll
+// use the TF_LOG env variable to set it to
+// Terraform
+func Init(out io.Writer, tflogs bool) {
+	once.Do(func() {
+		w := kitlog.NewSyncWriter(out)
+		logger = kitlog.NewLogfmtLogger(w)
+
+		if !tflogs {
+			os.Setenv("TF_LOG", "")
+			logging.SetOutput()
+		}
+
+		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
+	})
+}
+
+// Get returns the initialized logger,
+// if it has not been initialized it'll
+// initialize it with the default values
+func Get() kitlog.Logger {
+	Init(ioutil.Discard, false)
+	return logger
+}

--- a/provider/import.go
+++ b/provider/import.go
@@ -2,22 +2,31 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"io"
+
+	kitlog "github.com/go-kit/kit/log"
 
 	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/filter"
+	"github.com/cycloidio/terracognita/log"
 	"github.com/cycloidio/terracognita/writer"
 	"github.com/pkg/errors"
 )
 
 // Import imports from the Provider p all the resources filtered by f and writes
 // the result to the hcl or tfstate if those are not nil
-func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filter.Filter) error {
+func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filter.Filter, out io.Writer) error {
+	logger := log.Get()
+	logger = kitlog.With(logger, "func", "provider.Import")
+
 	var types []string
 
+	// Validate if the Include filter is right
 	if len(f.Include) != 0 {
 		for _, i := range f.Include {
 			if !p.HasResourceType(i) {
-				return errors.Wrapf(errcode.ErrProviderResourceNotSupported, "resource type %s", i)
+				return errors.Wrapf(errcode.ErrProviderResourceNotSupported, "type %s on Include filter", i)
 			}
 		}
 		types = f.Include
@@ -25,17 +34,40 @@ func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filt
 		types = p.ResourceTypes()
 	}
 
+	// Validate if the Exclude filter is right
+	if len(f.Exclude) != 0 {
+		for _, e := range f.Exclude {
+			if !p.HasResourceType(e) {
+				return errors.Wrapf(errcode.ErrProviderResourceNotSupported, "type %s on Exclude filter", e)
+			}
+		}
+	}
+
+	fmt.Fprintf(out, "Importing with filters: %s", f)
+	logger.Log("filters", f.String())
+
 	for _, t := range types {
+		logger = kitlog.With(logger, "resource", t)
+
 		if f.IsExcluded(t) {
+			logger.Log("msg", "excluded")
 			continue
 		}
+
+		logger.Log("msg", "fetching the list of resources")
 
 		resources, err := p.Resources(ctx, t, f)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 
-		for _, r := range resources {
+		resourceLen := len(resources)
+
+		for i, r := range resources {
+			logger := kitlog.With(logger, "id", r.ID(), "total", resourceLen, "current", i+1)
+			fmt.Fprintf(out, "\rImporting %s [%d/%d]", t, i+1, resourceLen)
+
+			logger.Log("msg", "reading from TF")
 			err := r.Read(f)
 			if err != nil {
 				cause := errors.Cause(err)
@@ -52,6 +84,7 @@ func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filt
 			}
 
 			if hcl != nil {
+				logger.Log("msg", "calculating HCL")
 				err = r.HCL(hcl)
 				if err != nil {
 					return errors.Wrapf(err, "error while calculating the Config of resource %q", t)
@@ -59,26 +92,43 @@ func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filt
 			}
 
 			if tfstate != nil {
+				logger.Log("msg", "calculating TFState")
 				err = r.State(tfstate)
 				if err != nil {
 					return errors.Wrapf(err, "error while calculating the Satate of resource %q", t)
 				}
 			}
 		}
+		if resourceLen > 0 {
+			fmt.Fprintf(out, "\rImporting %s [%d/%d] Done!\n", t, resourceLen, resourceLen)
+		}
+		logger.Log("msg", "importing done")
 	}
 
 	if hcl != nil {
+		fmt.Fprintf(out, "\rWriting HCL ...")
+		logger.Log("msg", "writing the HCL")
+
 		err := hcl.Sync()
 		if err != nil {
 			return errors.Wrapf(err, "error while Sync Config")
 		}
+
+		fmt.Fprintf(out, "\rWriting HCL Done!\n")
+		logger.Log("msg", "writing the HCL done")
 	}
 
 	if tfstate != nil {
+		fmt.Fprintf(out, "\rWriting TFState ...")
+		logger.Log("msg", "writing the TFState")
+
 		err := tfstate.Sync()
 		if err != nil {
 			return errors.Wrapf(err, "error while Sync State")
 		}
+
+		fmt.Fprintf(out, "\rWriting TFState Done!\n")
+		logger.Log("msg", "writing the TFState done")
 	}
 
 	return nil

--- a/provider/import_test.go
+++ b/provider/import_test.go
@@ -2,7 +2,7 @@ package provider_test
 
 import (
 	"context"
-	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/cycloidio/terracognita/errcode"
@@ -39,6 +39,11 @@ func TestImport(t *testing.T) {
 		p.EXPECT().Resources(ctx, "aws_instance", f).Return([]provider.Resource{instanceResoure1, instanceResoure2}, nil)
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
 
+		instanceResoure1.EXPECT().ID().Return("1")
+		instanceResoure2.EXPECT().ID().Return("2")
+		iamUser1.EXPECT().ID().Return("3")
+		iamUser2.EXPECT().ID().Return("4")
+
 		instanceResoure1.EXPECT().Read(f).Return(nil)
 		instanceResoure2.EXPECT().Read(f).Return(nil)
 		iamUser1.EXPECT().Read(f).Return(nil)
@@ -57,7 +62,7 @@ func TestImport(t *testing.T) {
 		hw.EXPECT().Sync().Return(nil)
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, sw, f)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessWithFilterInclude", func(t *testing.T) {
@@ -81,6 +86,9 @@ func TestImport(t *testing.T) {
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().Resources(ctx, "aws_instance", f).Return([]provider.Resource{instanceResoure1, instanceResoure2}, nil)
 
+		instanceResoure1.EXPECT().ID().Return("1")
+		instanceResoure2.EXPECT().ID().Return("2")
+
 		instanceResoure1.EXPECT().Read(f).Return(nil)
 		instanceResoure2.EXPECT().Read(f).Return(nil)
 
@@ -93,7 +101,7 @@ func TestImport(t *testing.T) {
 		hw.EXPECT().Sync().Return(nil)
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, sw, f)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessWithExclude", func(t *testing.T) {
@@ -114,9 +122,13 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
+
+		iamUser1.EXPECT().ID().Return("1")
+		iamUser2.EXPECT().ID().Return("2")
 
 		iamUser1.EXPECT().Read(f).Return(nil)
 		iamUser2.EXPECT().Read(f).Return(nil)
@@ -130,7 +142,7 @@ func TestImport(t *testing.T) {
 		hw.EXPECT().Sync().Return(nil)
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, sw, f)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessWithErrProviderResourceDoNotMatchTag", func(t *testing.T) {
@@ -151,9 +163,13 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
+
+		iamUser1.EXPECT().ID().Return("1")
+		iamUser2.EXPECT().ID().Return("2")
 
 		iamUser1.EXPECT().Read(f).Return(errcode.ErrProviderResourceDoNotMatchTag)
 		iamUser2.EXPECT().Read(f).Return(nil)
@@ -167,7 +183,7 @@ func TestImport(t *testing.T) {
 		hw.EXPECT().Sync().Return(nil)
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, sw, f)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessWithNoHCLWriter", func(t *testing.T) {
@@ -187,9 +203,13 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
+
+		iamUser1.EXPECT().ID().Return("1")
+		iamUser2.EXPECT().ID().Return("2")
 
 		iamUser1.EXPECT().Read(f).Return(errcode.ErrProviderResourceDoNotMatchTag)
 		iamUser2.EXPECT().Read(f).Return(nil)
@@ -199,7 +219,7 @@ func TestImport(t *testing.T) {
 
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, nil, sw, f)
+		err := provider.Import(ctx, p, nil, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessWithNoTFStateWriter", func(t *testing.T) {
@@ -219,9 +239,13 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
+
+		iamUser1.EXPECT().ID().Return("1")
+		iamUser2.EXPECT().ID().Return("2")
 
 		iamUser1.EXPECT().Read(f).Return(errcode.ErrProviderResourceDoNotMatchTag)
 		iamUser2.EXPECT().Read(f).Return(nil)
@@ -231,7 +255,7 @@ func TestImport(t *testing.T) {
 
 		hw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, nil, f)
+		err := provider.Import(ctx, p, hw, nil, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("ErrorWithErrProviderResourceNotRead", func(t *testing.T) {
@@ -252,9 +276,13 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
+
+		iamUser1.EXPECT().ID().Return("1")
+		iamUser2.EXPECT().ID().Return("2")
 
 		iamUser1.EXPECT().Read(f).Return(errcode.ErrProviderResourceNotRead)
 		iamUser2.EXPECT().Read(f).Return(nil)
@@ -266,7 +294,7 @@ func TestImport(t *testing.T) {
 		hw.EXPECT().Sync().Return(nil)
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, sw, f)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
 	t.Run("ErrorWithErrProviderResourceAutogenerated", func(t *testing.T) {
@@ -287,9 +315,13 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return([]provider.Resource{iamUser1, iamUser2}, nil)
+
+		iamUser1.EXPECT().ID().Return("1")
+		iamUser2.EXPECT().ID().Return("2")
 
 		iamUser1.EXPECT().Read(f).Return(errcode.ErrProviderResourceAutogenerated)
 		iamUser2.EXPECT().Read(f).Return(nil)
@@ -301,10 +333,10 @@ func TestImport(t *testing.T) {
 		hw.EXPECT().Sync().Return(nil)
 		sw.EXPECT().Sync().Return(nil)
 
-		err := provider.Import(ctx, p, hw, sw, f)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		require.NoError(t, err)
 	})
-	t.Run("ErrorWithIncorrectFilter", func(t *testing.T) {
+	t.Run("ErrorWithIncorrectFilterInclude", func(t *testing.T) {
 		var (
 			ctrl = gomock.NewController(t)
 			ctx  = context.Background()
@@ -323,8 +355,31 @@ func TestImport(t *testing.T) {
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().HasResourceType("aws_potato").Return(false)
 
-		err := provider.Import(ctx, p, hw, sw, f)
-		fmt.Println(err)
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
+		assert.Equal(t, errcode.ErrProviderResourceNotSupported.Error(), errors.Cause(err).Error())
+	})
+
+	t.Run("ErrorWithIncorrectFilterExclude", func(t *testing.T) {
+		var (
+			ctrl = gomock.NewController(t)
+			ctx  = context.Background()
+
+			p  = mock.NewProvider(ctrl)
+			hw = mock.NewWriter(ctrl)
+			sw = mock.NewWriter(ctrl)
+
+			f = &filter.Filter{
+				Exclude: []string{"aws_instance", "aws_potato"},
+			}
+		)
+
+		defer ctrl.Finish()
+
+		p.EXPECT().ResourceTypes().Return([]string{})
+		p.EXPECT().HasResourceType("aws_instance").Return(true)
+		p.EXPECT().HasResourceType("aws_potato").Return(false)
+
+		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
 		assert.Equal(t, errcode.ErrProviderResourceNotSupported.Error(), errors.Cause(err).Error())
 	})
 }

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -277,7 +277,6 @@ func setRootDefaults(cfgr *schema.ResourceData, sch map[string]*schema.Schema) {
 			cfgr.Set(k, v.Default)
 		}
 	}
-	return
 }
 
 // mergeFullConfig creates the key to the map and if it had a value before set it, if

--- a/util/retry.go
+++ b/util/retry.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/cycloidio/terracognita/log"
 )
 
 const (
@@ -30,6 +31,7 @@ func Retry(rfn RetryFn, times int, interval time.Duration) error {
 		}
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == AWSThrottlingCode {
+				log.Get().Log("func", "utils.Retry", "msg", "waiting for Throttling error", "times-left", times)
 				time.Sleep(interval)
 				return Retry(rfn, times, interval)
 			}

--- a/writer/state.go
+++ b/writer/state.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/cycloidio/terracognita/errcode"
+	"github.com/cycloidio/terracognita/log"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/pkg/errors"
 )
@@ -45,6 +46,8 @@ func (tfsw *TFStateWriter) Write(key string, value interface{}) error {
 		return errors.Wrapf(errcode.ErrWriterInvalidTypeValue, "expected *terraform.ResourceState, found %T", value)
 	}
 
+	log.Get().Log("func", "writer.Write(State)", "msg", "writing to internal config", "key", key, "content", &trs)
+
 	tfsw.Config[key] = trs
 
 	return nil
@@ -65,11 +68,12 @@ func (tfsw *TFStateWriter) Sync() error {
 	state := terraform.NewState()
 	state.AddModuleState(ms)
 
+	log.Get().Log("func", "writer.Write(State)", "msg", "transforming internal config to TFState JSON")
 	enc := json.NewEncoder(tfsw.w)
 	enc.SetIndent("", "  ")
 	err := enc.Encode(state)
 	if err != nil {
-		return fmt.Errorf("could not encode state due to: %s", err)
+		return fmt.Errorf("could not encode yestate due to: %s", err)
 	}
 
 	return nil

--- a/writer/state_test.go
+++ b/writer/state_test.go
@@ -123,6 +123,7 @@ func TestTFStateWriter_Sync(t *testing.T) {
 
 		var est map[string]interface{}
 		err = json.Unmarshal([]byte(state), &est)
+		require.NoError(t, err)
 
 		assert.Equal(t, est, st)
 	})


### PR DESCRIPTION
The `-verbose` uses go-kit/log to log information of what's currently happening on the import.

The `-debug` adds the `TF_LOG` so it also logs TF logs.

Closes #17 