### PR TITLE
ci: add GOPATH in PATH to run binaries from PWD/go/bin and Add base context for pull request notifications

### DIFF
--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -174,6 +174,7 @@ jobs:
 
       - put: pull-request
         params:
+          base_context: ((base-context))
           context: ((ci-context))
           path: pull-request
           status: pending
@@ -199,6 +200,7 @@ jobs:
         on_failure:
           put: pull-request
           params:
+            base_context: ((base-context))
             context: ((ci-context))
             path: pull-request
             status: failure
@@ -206,6 +208,7 @@ jobs:
         on_success:
           put: pull-request
           params:
+            base_context: ((base-context))
             context: ((ci-context))
             path: pull-request
             status: success

--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -16,6 +16,7 @@ shared:
     - '-ec'
     - |
       export GOPATH=${PWD}/go
+      export PATH="$GOPATH/bin:$PATH"
       cd code
       make lint
       go test ./...
@@ -327,6 +328,7 @@ jobs:
               - '-c'
               - |
                 export GOPATH=${PWD}/go
+                export PATH="$GOPATH/bin:$PATH"
                 cd code
                 make build-compress BUILD_PATH=../builds
           inputs:

--- a/.ci/variables.yml
+++ b/.ci/variables.yml
@@ -5,6 +5,7 @@ project: ($ project $)
 env: ($ environment $)
 customer: ($ organization_canonical $)
 
+base-context: cycloid-ci
 ci-context: terracognita
 
 # Git repository


### PR DESCRIPTION
- This PR fix the issue: `/bin/bash: golangci-lint: command not found` that we have in pipeline
- Add base context for pull request notifications
