### PR TITLE
Fixed: Error on formatting HCL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- HCL formatter to ignore some special keys that fail on the `fmtcmd` of HCL
+  ([Issue #36](https://github.com/cycloidio/terracognita/issues/36))
+
 ## [0.1.6] _2019-07-18_
 
 ### Added

--- a/writer/format_hcl.go
+++ b/writer/format_hcl.go
@@ -14,7 +14,7 @@ var (
 	}{
 		{
 			// Replace all the `"key" = "value"` for `key = "value"`
-			match:   regexp.MustCompile(`"([\w\-_\.]+)"\s=`),
+			match:   regexp.MustCompile(`"([^\d][\w\-_\.]+)"\s=`),
 			replace: []byte(`$1 =`),
 		},
 		{

--- a/writer/format_hcl_test.go
+++ b/writer/format_hcl_test.go
@@ -18,10 +18,14 @@ func TestFormatHCL(t *testing.T) {
 			in: []byte(`
 				"role" = value
 				"en.v" = "value"
+				"2tag" = "2value"
+				"t2tag" = "t2value"
 			`),
 			out: []byte(`
 				role = value
 				en.v = "value"
+				"2tag" = "2value"
+				t2tag = "t2value"
 			`),
 		},
 		{

--- a/writer/hcl.go
+++ b/writer/hcl.go
@@ -96,7 +96,10 @@ func (hclw *HCLWriter) Sync() error {
 
 	logger.Log("msg", "formatting HCL", "hcl", buff.String())
 
-	buff = bytes.NewBuffer(FormatHCL(buff.Bytes()))
+	formattedHCL := FormatHCL(buff.Bytes())
+	logger.Log("msg", "formatted HCL", "hcl", formattedHCL)
+
+	buff = bytes.NewBuffer(formattedHCL)
 
 	err = fmtcmd.Run(nil, nil, buff, hclw.w, fmtcmd.Options{})
 	if err != nil {


### PR DESCRIPTION
We had some errors with keys that started with a number, those should be keeped  as `"2key"` instead of `2key`.

Closes #36 