### PR TITLE
cmd: Add first line of logs telling which version of terracognita is running

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -71,6 +71,9 @@ var (
 			}
 
 			logger.Log("msg", "importing")
+
+			fmt.Fprintf(logsOut, "Starting Terracognita with version %s\n", Version)
+			logger.Log("msg", "starting terracognita", "version", Version)
 			err = provider.Import(ctx, awsP, hclW, stateW, f, logsOut)
 			if err != nil {
 				return fmt.Errorf("could not import from AWS: %+v", err)


### PR DESCRIPTION
This way with just the logs they know whic version they are running

```
Starting Terracognita with version v0.1.6-7-gefbd33d
Importing with filters: 
        Tags:    [],
        Include: [aws_ses_domain_identity_verification],
        Exclude: [],
Importing aws_ses_domain_identity_verification [2/2] Done!
Writing HCL Done!
Writing TFState Done!
```