### PR TITLE
README: Fix local path issue on install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You have 2 options to get the package:
 Then feel free to play with it :)
 
 ```
-$> cd $GOPATH/src/github/cycloidio/terracognita
+$> cd $GOPATH/src/github.com/cycloidio/terracognita
 $> make install
 ```
 


### PR DESCRIPTION
This PR fixes a local path after `go get` or cloning the repository, that caused an error if you try to follow the install steps.