### PR TITLE
Makefile: Replace golangci-lint for normal linters

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/mock/provider.go
+++ b/mock/provider.go
@@ -6,10 +6,11 @@ package mock
 
 import (
 	context "context"
+	reflect "reflect"
+
 	filter "github.com/cycloidio/terracognita/filter"
 	provider "github.com/cycloidio/terracognita/provider"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // Provider is a mock of Provider interface

--- a/mock/resource.go
+++ b/mock/resource.go
@@ -5,12 +5,13 @@
 package mock
 
 import (
+	reflect "reflect"
+
 	filter "github.com/cycloidio/terracognita/filter"
 	provider "github.com/cycloidio/terracognita/provider"
 	writer "github.com/cycloidio/terracognita/writer"
 	gomock "github.com/golang/mock/gomock"
 	schema "github.com/hashicorp/terraform/helper/schema"
-	reflect "reflect"
 )
 
 // Resource is a mock of Resource interface

--- a/mock/writer.go
+++ b/mock/writer.go
@@ -5,8 +5,9 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Writer is a mock of Writer interface


### PR DESCRIPTION
Only using 'goimports' and 'golint'.

It consumes to much memory and takes to much time.