### PR TITLE
CHANGELOG: Bump to version 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.2.0] _2019-10-29_
+
 This version changes the format of the TFState to the Terraform 0.12+ [format](https://www.terraform.io/upgrade-guides/0-12.html)
 
 ### Fixed


### PR DESCRIPTION
With the last PR migrating to TF 0.12, we'll have a new release for it.