### PR TITLE
README: Update the dockerhub link to be a public link to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ clean:                           Removes binary and/or docker image
 
 ### Docker
 
-You can use directly [the image built](https://cloud.docker.com/u/cycloid/repository/docker/cycloid/terracognita/general), or you can build your own.
+You can use directly [the image built](https://hub.docker.com/r/cycloid/terracognita), or you can build your own.
 To build your Docker image just run:
 
 ```bash


### PR DESCRIPTION
Before it was the logged it link which redirects users directly to the dockerhub homepage.

Closes https://github.com/cycloidio/terracognita/issues/59