### PR TITLE
google: backend configuration for load balancing

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -20,7 +20,7 @@ type google struct {
 }
 
 // NewProvider returns a Gooogle Provider
-func NewProvider(ctx context.Context, project, region, credentials string) (provider.Provider, error) {
+func NewProvider(ctx context.Context, maxResults uint64, project, region, credentials string) (provider.Provider, error) {
 	cfg := tfgoogle.Config{
 		Credentials: credentials,
 		Project:     project,
@@ -37,7 +37,7 @@ func NewProvider(ctx context.Context, project, region, credentials string) (prov
 	tfp.SetMeta(&cfg)
 
 	log.Get().Log("func", "google.NewProvider", "msg", "loading GCP client")
-	reader, err := NewGcpReader(ctx, project, region, credentials)
+	reader, err := NewGcpReader(ctx, maxResults, project, region, credentials)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize GCPReader: %v", err)
 	}

--- a/google/reader.go
+++ b/google/reader.go
@@ -4,36 +4,48 @@ import (
 	"context"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 )
 
 // GCPReader is the middleware between TC and GCP
 type GCPReader struct {
-	compute *compute.Service
-	project string
-	region  string
+	compute    *compute.Service
+	project    string
+	region     string
+	zones      []string
+	maxResults uint64
 }
 
 // NewGcpReader returns a GCPReader with a catalog of services
 // ready to be used
-func NewGcpReader(ctx context.Context, project, region, credentials string) (*GCPReader, error) {
+func NewGcpReader(ctx context.Context, maxResults uint64, project, region, credentials string) (*GCPReader, error) {
+	if maxResults > 500 {
+		return nil, errors.New("max-results must be between 0 and 500, inclusive")
+	}
 	comp, err := compute.NewService(ctx, option.WithCredentialsFile(credentials))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to create compute service")
 	}
 	return &GCPReader{
-		compute: comp,
-		project: project,
-		region:  region,
+		compute:    comp,
+		project:    project,
+		region:     region,
+		zones:      []string{},
+		maxResults: maxResults,
 	}, nil
 }
 
 func (r *GCPReader) getZones() ([]string, error) {
+	if len(r.zones) > 0 {
+		return r.zones, nil
+	}
 	rs := compute.NewRegionsService(r.compute)
 	region, err := rs.Get(r.project, r.region).Do()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "unable to fetch information for region %s", r.region)
 	}
 	// zones are URL format, e.g:
 	// https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c
@@ -43,6 +55,7 @@ func (r *GCPReader) getZones() ([]string, error) {
 		tmp := strings.Split(URL, "/")
 		zones = append(zones, tmp[len(tmp)-1])
 	}
+	r.zones = zones
 	return zones, nil
 }
 
@@ -52,20 +65,20 @@ func (r *GCPReader) ListInstances(ctx context.Context, filter string) (map[strin
 	instancesList := make(map[string][]compute.Instance)
 	zones, err := r.getZones()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to get zones in region")
 	}
 	for _, zone := range zones {
-		// 500 is the current `maxResults`
-		instances := make([]compute.Instance, 0, 500)
+		instances := make([]compute.Instance, 0)
 		if err := is.List(r.project, zone).
 			Filter(filter).
+			MaxResults(int64(r.maxResults)).
 			Pages(ctx, func(list *compute.InstanceList) error {
 				for _, instance := range list.Items {
 					instances = append(instances, *instance)
 				}
 				return nil
 			}); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to list compute instance from google APIs")
 		}
 		instancesList[zone] = instances
 	}
@@ -75,17 +88,17 @@ func (r *GCPReader) ListInstances(ctx context.Context, filter string) (map[strin
 // ListFirewalls return a list of firewalls in the project
 func (r *GCPReader) ListFirewalls(ctx context.Context, filter string) ([]compute.Firewall, error) {
 	is := compute.NewFirewallsService(r.compute)
-	// 500 is the current `maxResults`
-	firewalls := make([]compute.Firewall, 0, 500)
+	firewalls := make([]compute.Firewall, 0)
 	if err := is.List(r.project).
 		Filter(filter).
+		MaxResults(int64(r.maxResults)).
 		Pages(ctx, func(list *compute.FirewallList) error {
 			for _, firewall := range list.Items {
 				firewalls = append(firewalls, *firewall)
 			}
 			return nil
 		}); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to list firewalls from google APIs")
 	}
 	return firewalls, nil
 }
@@ -93,17 +106,79 @@ func (r *GCPReader) ListFirewalls(ctx context.Context, filter string) ([]compute
 // ListNetworks return a list of networks in the project
 func (r *GCPReader) ListNetworks(ctx context.Context, filter string) ([]compute.Network, error) {
 	ns := compute.NewNetworksService(r.compute)
-	// 500 is the current `maxResults`
-	networks := make([]compute.Network, 0, 500)
+	networks := make([]compute.Network, 0)
 	if err := ns.List(r.project).
 		Filter(filter).
+		MaxResults(int64(r.maxResults)).
 		Pages(ctx, func(list *compute.NetworkList) error {
 			for _, network := range list.Items {
 				networks = append(networks, *network)
 			}
 			return nil
 		}); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to list networks from google APIs")
 	}
 	return networks, nil
+}
+
+// ListHealthCheck returns a list of health checks in the project
+func (r *GCPReader) ListHealthCheck(ctx context.Context, filter string) ([]compute.HealthCheck, error) {
+	ns := compute.NewHealthChecksService(r.compute)
+	checks := make([]compute.HealthCheck, 0)
+	if err := ns.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.HealthCheckList) error {
+			for _, check := range list.Items {
+				checks = append(checks, *check)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list health checks from google APIs")
+	}
+	return checks, nil
+}
+
+// ListInstanceGroup returns a list of instance groups in the project within a zone
+func (r *GCPReader) ListInstanceGroup(ctx context.Context, filter string) (map[string][]compute.InstanceGroup, error) {
+	igs := compute.NewInstanceGroupsService(r.compute)
+	instanceGroupList := make(map[string][]compute.InstanceGroup)
+	zones, err := r.getZones()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get zones in region")
+	}
+	for _, zone := range zones {
+		groups := make([]compute.InstanceGroup, 0)
+		if err := igs.List(r.project, zone).
+			Filter(filter).
+			MaxResults(int64(r.maxResults)).
+			Pages(ctx, func(list *compute.InstanceGroupList) error {
+				for _, group := range list.Items {
+					groups = append(groups, *group)
+				}
+				return nil
+			}); err != nil {
+			return nil, errors.Wrap(err, "unable to list instance groups from google APIs")
+		}
+		instanceGroupList[zone] = groups
+	}
+	return instanceGroupList, nil
+}
+
+// ListBackendService returns a list of backend service in the project
+func (r *GCPReader) ListBackendService(ctx context.Context, filter string) ([]compute.BackendService, error) {
+	bs := compute.NewBackendServicesService(r.compute)
+	backends := make([]compute.BackendService, 0)
+	if err := bs.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.BackendServiceList) error {
+			for _, backend := range list.Items {
+				backends = append(backends, *backend)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list backend services from google APIs")
+	}
+	return backends, nil
 }

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_network"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_service"
 
-var _ResourceTypeIndex = [...]uint8{0, 23, 46, 68}
+var _ResourceTypeIndex = [...]uint8{0, 23, 46, 68, 95, 124, 154}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_network"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_service"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,21 +19,30 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
-	_ResourceTypeName[0:23]:       0,
-	_ResourceTypeLowerName[0:23]:  0,
-	_ResourceTypeName[23:46]:      1,
-	_ResourceTypeLowerName[23:46]: 1,
-	_ResourceTypeName[46:68]:      2,
-	_ResourceTypeLowerName[46:68]: 2,
+	_ResourceTypeName[0:23]:         0,
+	_ResourceTypeLowerName[0:23]:    0,
+	_ResourceTypeName[23:46]:        1,
+	_ResourceTypeLowerName[23:46]:   1,
+	_ResourceTypeName[46:68]:        2,
+	_ResourceTypeLowerName[46:68]:   2,
+	_ResourceTypeName[68:95]:        3,
+	_ResourceTypeLowerName[68:95]:   3,
+	_ResourceTypeName[95:124]:       4,
+	_ResourceTypeLowerName[95:124]:  4,
+	_ResourceTypeName[124:154]:      5,
+	_ResourceTypeLowerName[124:154]: 5,
 }
 
 var _ResourceTypeNames = []string{
 	_ResourceTypeName[0:23],
 	_ResourceTypeName[23:46],
 	_ResourceTypeName[46:68],
+	_ResourceTypeName[68:95],
+	_ResourceTypeName[95:124],
+	_ResourceTypeName[124:154],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
In this PR: 

- custom cache for google internal resources
- three components (see below)

Following google documentation: 

HTTP(S) load balancer has 3 parts:

#### Backend configuration (this PR)
A backend service directs incoming traffic to an instance group. You can also use a storage bucket to serve content.
For now, I just implemented instance_group + backend_service + health_check components.

#### Host and path rules
Host and path rules determine how your traffic will be directed. If you don't specify any rules, traffic will be sent to the default backend service.

#### Frontend configuration
Your IP address, protocol and port. This is the IP to which your client requests will come in to.

More information [here](https://cloud.google.com/load-balancing/docs/https/)
