### PR TITLE
google: intermediate configuration for load balancing

### DIFF
--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -16,6 +16,10 @@ var functions = []Function{
 	Function{Resource: "InstanceGroup", Zone: true},
 	Function{Resource: "BackendService", Zone: false},
 	Function{Resource: "HealthCheck", Zone: false},
+	Function{Resource: "UrlMap", Zone: false, Name: "URLMaps"},
+	Function{Resource: "TargetHttpProxy", Zone: false, Name: "TargetHTTPProxies", ServiceName: "TargetHttpProxies"},
+	Function{Resource: "TargetHttpsProxy", Zone: false, Name: "TargetHTTPSProxies", ServiceName: "TargetHttpsProxies"},
+	Function{Resource: "SslCertificate", Zone: false, Name: "SSLCertificates"},
 }
 
 func main() {

--- a/google/reader_generated.go
+++ b/google/reader_generated.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-// ListInstances will returns a list of Instance within a project and a zone
+// ListInstances returns a list of Instances within a project and a zone
 func (r *GCPReader) ListInstances(ctx context.Context, filter string) (map[string][]compute.Instance, error) {
 	service := compute.NewInstancesService(r.compute)
 
@@ -40,7 +40,7 @@ func (r *GCPReader) ListInstances(ctx context.Context, filter string) (map[strin
 
 }
 
-// ListFirewalls will returns a list of Firewall within a project
+// ListFirewalls returns a list of Firewalls within a project
 func (r *GCPReader) ListFirewalls(ctx context.Context, filter string) ([]compute.Firewall, error) {
 	service := compute.NewFirewallsService(r.compute)
 
@@ -62,7 +62,7 @@ func (r *GCPReader) ListFirewalls(ctx context.Context, filter string) ([]compute
 
 }
 
-// ListNetworks will returns a list of Network within a project
+// ListNetworks returns a list of Networks within a project
 func (r *GCPReader) ListNetworks(ctx context.Context, filter string) ([]compute.Network, error) {
 	service := compute.NewNetworksService(r.compute)
 
@@ -84,7 +84,7 @@ func (r *GCPReader) ListNetworks(ctx context.Context, filter string) ([]compute.
 
 }
 
-// ListInstanceGroups will returns a list of InstanceGroup within a project and a zone
+// ListInstanceGroups returns a list of InstanceGroups within a project and a zone
 func (r *GCPReader) ListInstanceGroups(ctx context.Context, filter string) (map[string][]compute.InstanceGroup, error) {
 	service := compute.NewInstanceGroupsService(r.compute)
 
@@ -115,7 +115,7 @@ func (r *GCPReader) ListInstanceGroups(ctx context.Context, filter string) (map[
 
 }
 
-// ListBackendServices will returns a list of BackendService within a project
+// ListBackendServices returns a list of BackendServices within a project
 func (r *GCPReader) ListBackendServices(ctx context.Context, filter string) ([]compute.BackendService, error) {
 	service := compute.NewBackendServicesService(r.compute)
 
@@ -137,7 +137,7 @@ func (r *GCPReader) ListBackendServices(ctx context.Context, filter string) ([]c
 
 }
 
-// ListHealthChecks will returns a list of HealthCheck within a project
+// ListHealthChecks returns a list of HealthChecks within a project
 func (r *GCPReader) ListHealthChecks(ctx context.Context, filter string) ([]compute.HealthCheck, error) {
 	service := compute.NewHealthChecksService(r.compute)
 
@@ -153,6 +153,94 @@ func (r *GCPReader) ListHealthChecks(ctx context.Context, filter string) ([]comp
 			return nil
 		}); err != nil {
 		return nil, errors.Wrap(err, "unable to list compute HealthCheck from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListURLMaps returns a list of URLMaps within a project
+func (r *GCPReader) ListURLMaps(ctx context.Context, filter string) ([]compute.UrlMap, error) {
+	service := compute.NewUrlMapsService(r.compute)
+
+	resources := make([]compute.UrlMap, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.UrlMapList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute UrlMap from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListTargetHTTPProxies returns a list of TargetHTTPProxies within a project
+func (r *GCPReader) ListTargetHTTPProxies(ctx context.Context, filter string) ([]compute.TargetHttpProxy, error) {
+	service := compute.NewTargetHttpProxiesService(r.compute)
+
+	resources := make([]compute.TargetHttpProxy, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.TargetHttpProxyList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute TargetHttpProxy from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListTargetHTTPSProxies returns a list of TargetHTTPSProxies within a project
+func (r *GCPReader) ListTargetHTTPSProxies(ctx context.Context, filter string) ([]compute.TargetHttpsProxy, error) {
+	service := compute.NewTargetHttpsProxiesService(r.compute)
+
+	resources := make([]compute.TargetHttpsProxy, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.TargetHttpsProxyList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute TargetHttpsProxy from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListSSLCertificates returns a list of SSLCertificates within a project
+func (r *GCPReader) ListSSLCertificates(ctx context.Context, filter string) ([]compute.SslCertificate, error) {
+	service := compute.NewSslCertificatesService(r.compute)
+
+	resources := make([]compute.SslCertificate, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.SslCertificateList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute SslCertificate from google APIs")
 	}
 
 	return resources, nil

--- a/google/resources.go
+++ b/google/resources.go
@@ -27,18 +27,26 @@ const (
 	ComputeHealthCheck
 	ComputeInstanceGroup
 	ComputeBackendService
+	ComputeSSLCertificate
+	ComputeTargetHTTPProxy
+	ComputeTargetHTTPSProxy
+	ComputeURLMap
 )
 
 type rtFn func(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
 
 var (
 	resources = map[ResourceType]rtFn{
-		ComputeInstance:       computeInstance,
-		ComputeFirewall:       computeFirewall,
-		ComputeNetwork:        computeNetwork,
-		ComputeHealthCheck:    computeHealthCheck,
-		ComputeInstanceGroup:  computeInstanceGroup,
-		ComputeBackendService: computeBackendService,
+		ComputeInstance:         computeInstance,
+		ComputeFirewall:         computeFirewall,
+		ComputeNetwork:          computeNetwork,
+		ComputeHealthCheck:      computeHealthCheck,
+		ComputeInstanceGroup:    computeInstanceGroup,
+		ComputeBackendService:   computeBackendService,
+		ComputeSSLCertificate:   computeSSLCertificate,
+		ComputeTargetHTTPProxy:  computeTargetHTTPProxy,
+		ComputeTargetHTTPSProxy: computeTargetHTTPSProxy,
+		ComputeURLMap:           computeURLMap,
 	}
 )
 
@@ -134,6 +142,62 @@ func computeBackendService(ctx context.Context, g *google, resourceType string, 
 	resources := make([]provider.Resource, 0)
 	for _, backend := range backends {
 		r := provider.NewResource(backend.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func computeURLMap(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	maps, err := g.gcpr.ListURLMaps(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list URL maps from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, urlMap := range maps {
+		r := provider.NewResource(urlMap.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func computeTargetHTTPProxy(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	targets, err := g.gcpr.ListTargetHTTPProxies(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list target http proxies from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, target := range targets {
+		r := provider.NewResource(target.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func computeTargetHTTPSProxy(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	targets, err := g.gcpr.ListTargetHTTPSProxies(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list target https proxies from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, target := range targets {
+		r := provider.NewResource(target.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func computeSSLCertificate(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	certs, err := g.gcpr.ListSSLCertificates(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list SSL certificates from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, cert := range certs {
+		r := provider.NewResource(cert.Name, resourceType, g)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_service"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_map"
 
-var _ResourceTypeIndex = [...]uint8{0, 23, 46, 68, 95, 124, 154}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_service"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_map"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -34,6 +34,14 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[95:124]:  4,
 	_ResourceTypeName[124:154]:      5,
 	_ResourceTypeLowerName[124:154]: 5,
+	_ResourceTypeName[154:184]:      6,
+	_ResourceTypeLowerName[154:184]: 6,
+	_ResourceTypeName[184:216]:      7,
+	_ResourceTypeLowerName[184:216]: 7,
+	_ResourceTypeName[216:249]:      8,
+	_ResourceTypeLowerName[216:249]: 8,
+	_ResourceTypeName[249:271]:      9,
+	_ResourceTypeLowerName[249:271]: 9,
 }
 
 var _ResourceTypeNames = []string{
@@ -43,6 +51,10 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[68:95],
 	_ResourceTypeName[95:124],
 	_ResourceTypeName[124:154],
+	_ResourceTypeName[154:184],
+	_ResourceTypeName[184:216],
+	_ResourceTypeName[216:249],
+	_ResourceTypeName[249:271],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
In this PR: 

- four components (see below). I was not able to use the generator since there are two proxies component and the template is based on the plural of a component (Instance -> Instances but Proxy -> ProxIES). Same for Ssl and Url (not compliant with the go lint)

Following google documentation: 

HTTP(S) load balancer has 3 parts:

#### Backend configuration (#64 )
A backend service directs incoming traffic to an instance group. You can also use a storage bucket to serve content.
For now, I just implemented instance_group + backend_service + health_check components.

#### Host and path rules (this PR)
Host and path rules determine how your traffic will be directed. If you don't specify any rules, traffic will be sent to the default backend service.
target_http(s)_proxy, url_map and ssl_certificate (for https)


#### Frontend configuration
Your IP address, protocol and port. This is the IP to which your client requests will come in to.

More information [here](https://cloud.google.com/load-balancing/docs/https/)

![toto](https://cloud.google.com/load-balancing/images/https-load-balancer-diagram.svg)
