### PR TITLE
forwarding rule for the HTTP(S) LB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- google resource: `ComputeSSLCertificate`, `ComputeTargetHTTPProxy`, `ComputeTargetHTTPSProxy` and `ComputeURLMap`
+  ([PR #67](https://github.com/cycloidio/terracognita/pull/67))
+- google resource: `ComputeHealthCheck`, `ComputeInstanceGroup` and `ComputeBackendService`
+  ([PR #64](https://github.com/cycloidio/terracognita/pull/64))
 - aws resource: `aws_launch_configuration`, `aws_launch_template` and `aws_autoscaling_group`
   ([PR #68](https://github.com/cycloidio/terracognita/pull/68))
 - google resource: compute instance

--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -21,6 +21,7 @@ var functions = []Function{
 	Function{Resource: "TargetHttpsProxy", Zone: false, Name: "TargetHTTPSProxies", ServiceName: "TargetHttpsProxies"},
 	Function{Resource: "SslCertificate", Zone: false, Name: "SSLCertificates"},
 	Function{Resource: "ForwardingRule", Zone: false, Name: "GlobalForwardingRules", ServiceName: "GlobalForwardingRules"},
+	Function{Resource: "ForwardingRule", Region: true},
 }
 
 func main() {

--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -20,6 +20,7 @@ var functions = []Function{
 	Function{Resource: "TargetHttpProxy", Zone: false, Name: "TargetHTTPProxies", ServiceName: "TargetHttpProxies"},
 	Function{Resource: "TargetHttpsProxy", Zone: false, Name: "TargetHTTPSProxies", ServiceName: "TargetHttpsProxies"},
 	Function{Resource: "SslCertificate", Zone: false, Name: "SSLCertificates"},
+	Function{Resource: "ForwardingRule", Zone: false, Name: "GlobalForwardingRules", ServiceName: "GlobalForwardingRules"},
 }
 
 func main() {

--- a/google/cmd/template.go
+++ b/google/cmd/template.go
@@ -37,6 +37,8 @@ const (
 		resources := make([]compute.{{ .Resource }}, 0)
 		{{ if .Zone }}
 		if err := service.List(r.project, zone).
+		{{ else if .Region }}
+		if err := service.List(r.project, r.region).
 		{{ else }}
 		if err := service.List(r.project).
 		{{ end }}
@@ -98,6 +100,9 @@ type Function struct {
 	// If your service is `TargetHttpProxy`, your service name will
 	// be `TargetHttpProxies`
 	ServiceName string
+
+	// Region is used to determine whether the resource is dedicated to a region or not
+	Region bool
 }
 
 // Execute uses the fnTmpl to interpolate f

--- a/google/reader_generated.go
+++ b/google/reader_generated.go
@@ -268,3 +268,25 @@ func (r *GCPReader) ListGlobalForwardingRules(ctx context.Context, filter string
 	return resources, nil
 
 }
+
+// ListForwardingRules returns a list of ForwardingRules within a project
+func (r *GCPReader) ListForwardingRules(ctx context.Context, filter string) ([]compute.ForwardingRule, error) {
+	service := compute.NewForwardingRulesService(r.compute)
+
+	resources := make([]compute.ForwardingRule, 0)
+
+	if err := service.List(r.project, r.region).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.ForwardingRuleList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute ForwardingRule from google APIs")
+	}
+
+	return resources, nil
+
+}

--- a/google/reader_generated.go
+++ b/google/reader_generated.go
@@ -246,3 +246,25 @@ func (r *GCPReader) ListSSLCertificates(ctx context.Context, filter string) ([]c
 	return resources, nil
 
 }
+
+// ListGlobalForwardingRules returns a list of GlobalForwardingRules within a project
+func (r *GCPReader) ListGlobalForwardingRules(ctx context.Context, filter string) ([]compute.ForwardingRule, error) {
+	service := compute.NewGlobalForwardingRulesService(r.compute)
+
+	resources := make([]compute.ForwardingRule, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.ForwardingRuleList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute ForwardingRule from google APIs")
+	}
+
+	return resources, nil
+
+}

--- a/google/resources.go
+++ b/google/resources.go
@@ -32,6 +32,7 @@ const (
 	ComputeTargetHTTPSProxy
 	ComputeURLMap
 	ComputeGlobalForwardingRule
+	ComputeForwardingRule
 )
 
 type rtFn func(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
@@ -49,6 +50,7 @@ var (
 		ComputeTargetHTTPSProxy:     computeTargetHTTPSProxy,
 		ComputeURLMap:               computeURLMap,
 		ComputeGlobalForwardingRule: computeGlobalForwardingRule,
+		ComputeForwardingRule:       computeForwardingRule,
 	}
 )
 
@@ -208,6 +210,20 @@ func computeSSLCertificate(ctx context.Context, g *google, resourceType string, 
 func computeGlobalForwardingRule(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
 	f := initializeFilter(tags)
 	rules, err := g.gcpr.ListGlobalForwardingRules(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, rule := range rules {
+		r := provider.NewResource(rule.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func computeForwardingRule(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	rules, err := g.gcpr.ListForwardingRules(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
 	}

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rule"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rule"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rule"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rule"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -44,6 +44,8 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[249:271]: 9,
 	_ResourceTypeName[271:308]:      10,
 	_ResourceTypeLowerName[271:308]: 10,
+	_ResourceTypeName[308:338]:      11,
+	_ResourceTypeLowerName[308:338]: 11,
 }
 
 var _ResourceTypeNames = []string{
@@ -58,6 +60,7 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[216:249],
 	_ResourceTypeName[249:271],
 	_ResourceTypeName[271:308],
+	_ResourceTypeName[308:338],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_map"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rule"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_map"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rule"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -42,6 +42,8 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[216:249]: 8,
 	_ResourceTypeName[249:271]:      9,
 	_ResourceTypeLowerName[249:271]: 9,
+	_ResourceTypeName[271:308]:      10,
+	_ResourceTypeLowerName[271:308]: 10,
 }
 
 var _ResourceTypeNames = []string{
@@ -55,6 +57,7 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[184:216],
 	_ResourceTypeName[216:249],
 	_ResourceTypeName[249:271],
+	_ResourceTypeName[271:308],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This is the final components of the HTTP(S) Google LB.
In this PR, we add two more components: `GlobalForwardingRule` and `ForwardingRule`. They are the entrypoint of the LB to redirect request to the `TargetHttp(s)Proxies`.

- `ForwardingRule` is specific to a region, this is why we slightly updated the template to take the `region` in consideration if needed.
- `GlobalForwardingRule` is the same thing but it's region-agnostic.  

More informations on this components [there](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#https_lb)

Changelog has also been updated to add the components of #67 and #64 