### PR TITLE
add several components

### DIFF
--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -22,6 +22,7 @@ var functions = []Function{
 	Function{Resource: "SslCertificate", Zone: false, Name: "SSLCertificates"},
 	Function{Resource: "ForwardingRule", Zone: false, Name: "GlobalForwardingRules", ServiceName: "GlobalForwardingRules"},
 	Function{Resource: "ForwardingRule", Region: true},
+	Function{Resource: "Disk", Zone: true},
 }
 
 func main() {

--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -23,6 +23,7 @@ var functions = []Function{
 	Function{Resource: "ForwardingRule", Zone: false, Name: "GlobalForwardingRules", ServiceName: "GlobalForwardingRules"},
 	Function{Resource: "ForwardingRule", Region: true},
 	Function{Resource: "Disk", Zone: true},
+	Function{Resource: "Bucket", NoFilter: true, API: "storage", ResourceList: "Buckets"},
 }
 
 func main() {

--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -24,6 +24,7 @@ var functions = []Function{
 	Function{Resource: "ForwardingRule", Region: true},
 	Function{Resource: "Disk", Zone: true},
 	Function{Resource: "Bucket", NoFilter: true, API: "storage", ResourceList: "Buckets"},
+	Function{Resource: "DatabaseInstance", Name: "StorageInstances", API: "sqladmin", ResourceList: "InstancesListResponse", ServiceName: "Instances"},
 }
 
 func main() {

--- a/google/cmd/template.go
+++ b/google/cmd/template.go
@@ -18,6 +18,7 @@ const (
 		"github.com/pkg/errors"
 
 		"google.golang.org/api/compute/v1"
+		"google.golang.org/api/sqladmin/v1beta4"
 		"google.golang.org/api/storage/v1"
 	)
 	`

--- a/google/reader.go
+++ b/google/reader.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
+	"google.golang.org/api/storage/v1"
 )
 
 //go:generate go run ./cmd
@@ -15,6 +16,7 @@ import (
 // GCPReader is the middleware between TC and GCP
 type GCPReader struct {
 	compute    *compute.Service
+	storage    *storage.Service
 	project    string
 	region     string
 	zones      []string
@@ -31,8 +33,13 @@ func NewGcpReader(ctx context.Context, maxResults uint64, project, region, crede
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create compute service")
 	}
+	storage, err := storage.NewService(ctx, option.WithCredentialsFile(credentials))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create storage service")
+	}
 	return &GCPReader{
 		compute:    comp,
+		storage:    storage,
 		project:    project,
 		region:     region,
 		zones:      []string{},

--- a/google/reader.go
+++ b/google/reader.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 	"google.golang.org/api/storage/v1"
 )
 
@@ -17,6 +18,7 @@ import (
 type GCPReader struct {
 	compute    *compute.Service
 	storage    *storage.Service
+	sqladmin   *sqladmin.Service
 	project    string
 	region     string
 	zones      []string
@@ -37,9 +39,14 @@ func NewGcpReader(ctx context.Context, maxResults uint64, project, region, crede
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create storage service")
 	}
+	sql, err := sqladmin.NewService(ctx, option.WithCredentialsFile(credentials))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create sqladmin service")
+	}
 	return &GCPReader{
 		compute:    comp,
 		storage:    storage,
+		sqladmin:   sql,
 		project:    project,
 		region:     region,
 		zones:      []string{},

--- a/google/resources.go
+++ b/google/resources.go
@@ -33,6 +33,7 @@ const (
 	ComputeURLMap
 	ComputeGlobalForwardingRule
 	ComputeForwardingRule
+	ComputeDisk
 )
 
 type rtFn func(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
@@ -51,6 +52,7 @@ var (
 		ComputeURLMap:               computeURLMap,
 		ComputeGlobalForwardingRule: computeGlobalForwardingRule,
 		ComputeForwardingRule:       computeForwardingRule,
+		ComputeDisk:                 computeDisk,
 	}
 )
 
@@ -231,6 +233,22 @@ func computeForwardingRule(ctx context.Context, g *google, resourceType string, 
 	for _, rule := range rules {
 		r := provider.NewResource(rule.Name, resourceType, g)
 		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func computeDisk(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	disksList, err := g.gcpr.ListDisks(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list disks from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for z, disks := range disksList {
+		for _, disk := range disks {
+			r := provider.NewResource(fmt.Sprintf("%s/%s", z, disk.Name), resourceType, g)
+			resources = append(resources, r)
+		}
 	}
 	return resources, nil
 }

--- a/google/resources.go
+++ b/google/resources.go
@@ -34,6 +34,7 @@ const (
 	ComputeGlobalForwardingRule
 	ComputeForwardingRule
 	ComputeDisk
+	StorageBucket
 )
 
 type rtFn func(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
@@ -53,6 +54,7 @@ var (
 		ComputeGlobalForwardingRule: computeGlobalForwardingRule,
 		ComputeForwardingRule:       computeForwardingRule,
 		ComputeDisk:                 computeDisk,
+		StorageBucket:               storageBucket,
 	}
 )
 
@@ -249,6 +251,19 @@ func computeDisk(ctx context.Context, g *google, resourceType string, tags []tag
 			r := provider.NewResource(fmt.Sprintf("%s/%s", z, disk.Name), resourceType, g)
 			resources = append(resources, r)
 		}
+	}
+	return resources, nil
+}
+
+func storageBucket(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	rules, err := g.gcpr.ListBuckets(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, rule := range rules {
+		r := provider.NewResource(rule.Name, resourceType, g)
+		resources = append(resources, r)
 	}
 	return resources, nil
 }

--- a/google/resources.go
+++ b/google/resources.go
@@ -35,6 +35,7 @@ const (
 	ComputeForwardingRule
 	ComputeDisk
 	StorageBucket
+	SQLDatabaseInstance
 )
 
 type rtFn func(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
@@ -55,6 +56,7 @@ var (
 		ComputeForwardingRule:       computeForwardingRule,
 		ComputeDisk:                 computeDisk,
 		StorageBucket:               storageBucket,
+		SQLDatabaseInstance:         sqlDatabaseInstance,
 	}
 )
 
@@ -263,6 +265,20 @@ func storageBucket(ctx context.Context, g *google, resourceType string, tags []t
 	resources := make([]provider.Resource, 0)
 	for _, rule := range rules {
 		r := provider.NewResource(rule.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func sqlDatabaseInstance(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	f := initializeFilter(tags)
+	instances, err := g.gcpr.ListStorageInstances(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list sql storage instances rules from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, instance := range instances {
+		r := provider.NewResource(instance.Name, resourceType, g)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_disk"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucket"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 378}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_disk"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucket"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -48,6 +48,8 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[308:338]: 11,
 	_ResourceTypeName[338:357]:      12,
 	_ResourceTypeLowerName[338:357]: 12,
+	_ResourceTypeName[357:378]:      13,
+	_ResourceTypeLowerName[357:378]: 13,
 }
 
 var _ResourceTypeNames = []string{
@@ -64,6 +66,7 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[271:308],
 	_ResourceTypeName[308:338],
 	_ResourceTypeName[338:357],
+	_ResourceTypeName[357:378],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rule"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_disk"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rule"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_disk"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -46,6 +46,8 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[271:308]: 10,
 	_ResourceTypeName[308:338]:      11,
 	_ResourceTypeLowerName[308:338]: 11,
+	_ResourceTypeName[338:357]:      12,
+	_ResourceTypeLowerName[338:357]: 12,
 }
 
 var _ResourceTypeNames = []string{
@@ -61,6 +63,7 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[249:271],
 	_ResourceTypeName[271:308],
 	_ResourceTypeName[308:338],
+	_ResourceTypeName[338:357],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucket"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucketgoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 378}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 378, 406}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucket"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucketgoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -50,6 +50,8 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[338:357]: 12,
 	_ResourceTypeName[357:378]:      13,
 	_ResourceTypeLowerName[357:378]: 13,
+	_ResourceTypeName[378:406]:      14,
+	_ResourceTypeLowerName[378:406]: 14,
 }
 
 var _ResourceTypeNames = []string{
@@ -67,6 +69,7 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[308:338],
 	_ResourceTypeName[338:357],
 	_ResourceTypeName[357:378],
+	_ResourceTypeName[378:406],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
In this PR, I added three more components for Google provider:

- `google_sql_database_instance` (SQL service)
- `google_storage_bucket` (Cloud storage)
- `google_compute_disk` (Persistent disks)

For the first time, we are using APIs different than `compute`. I slightly updated the template to handle different APIs (new field `API`).

As mentioned in this commit: https://github.com/cycloidio/terracognita/commit/c29aad5d174ce7956795a40d6ce3d02f5f86514a, you'll need to enable SQL APIs if you want to play with SQL instances.

I also added a field `NoFilter` field since `buckets` can not be filtered.