### PR TITLE
Google cloud DNS components

### DIFF
--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -25,6 +25,7 @@ var functions = []Function{
 	Function{Resource: "Disk", Zone: true},
 	Function{Resource: "Bucket", NoFilter: true, API: "storage", ResourceList: "Buckets"},
 	Function{Resource: "DatabaseInstance", Name: "StorageInstances", API: "sqladmin", ResourceList: "InstancesListResponse", ServiceName: "Instances"},
+	Function{Resource: "ManagedZone", API: "dns", ResourceList: "ManagedZonesListResponse", NoFilter: true, ItemName: "ManagedZones"},
 }
 
 func main() {

--- a/google/cmd/template.go
+++ b/google/cmd/template.go
@@ -49,7 +49,7 @@ const (
 		{{ end }}
 			MaxResults(int64(r.maxResults)).
 			Pages(ctx, func(list *{{ .API }}.{{ .ResourceList }}) error {
-				for _, res := range list.Items {
+				for _, res := range list.{{ .ItemName }}{
 					resources = append(resources, *res)
 				}
 				return nil
@@ -126,6 +126,11 @@ type Function struct {
 	// for the components Instance, the list struct is `InstanceList`
 	// but for the components Bucket, the list struct is `Buckets`
 	ResourceList string
+
+	// ItemName overrides the default name of
+	// of the list of resources inside the List elements
+	// fetch by TC
+	ItemName string
 }
 
 // Execute uses the fnTmpl to interpolate f
@@ -142,6 +147,9 @@ func (f Function) Execute(w io.Writer) error {
 	}
 	if len(f.ServiceName) == 0 {
 		f.ServiceName = f.Resource + "s"
+	}
+	if len(f.ItemName) == 0 {
+		f.ItemName = "Items"
 	}
 	if err := fnTmpl.Execute(w, f); err != nil {
 		return errors.Wrapf(err, "failed to Execute with Function %+v", f)

--- a/google/reader.go
+++ b/google/reader.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 	"google.golang.org/api/storage/v1"
@@ -19,6 +20,7 @@ type GCPReader struct {
 	compute    *compute.Service
 	storage    *storage.Service
 	sqladmin   *sqladmin.Service
+	dns        *dns.Service
 	project    string
 	region     string
 	zones      []string
@@ -43,12 +45,17 @@ func NewGcpReader(ctx context.Context, maxResults uint64, project, region, crede
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create sqladmin service")
 	}
+	d, err := dns.NewService(ctx, option.WithCredentialsFile(credentials))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create sqladmin service")
+	}
 	return &GCPReader{
 		compute:    comp,
 		storage:    storage,
 		sqladmin:   sql,
 		project:    project,
 		region:     region,
+		dns:        d,
 		zones:      []string{},
 		maxResults: maxResults,
 	}, nil

--- a/google/reader_generated.go
+++ b/google/reader_generated.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/dns/v1"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 	"google.golang.org/api/storage/v1"
 )
@@ -361,6 +362,27 @@ func (r *GCPReader) ListStorageInstances(ctx context.Context, filter string) ([]
 			return nil
 		}); err != nil {
 		return nil, errors.Wrap(err, "unable to list sqladmin DatabaseInstance from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListManagedZones returns a list of ManagedZones within a project
+func (r *GCPReader) ListManagedZones(ctx context.Context) ([]dns.ManagedZone, error) {
+	service := dns.NewManagedZonesService(r.dns)
+
+	resources := make([]dns.ManagedZone, 0)
+
+	if err := service.List(r.project).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *dns.ManagedZonesListResponse) error {
+			for _, res := range list.ManagedZones {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list dns ManagedZone from google APIs")
 	}
 
 	return resources, nil

--- a/google/resources.go
+++ b/google/resources.go
@@ -34,6 +34,7 @@ const (
 	ComputeGlobalForwardingRule
 	ComputeForwardingRule
 	ComputeDisk
+	DNSManagedZone
 	StorageBucket
 	SQLDatabaseInstance
 )
@@ -55,6 +56,7 @@ var (
 		ComputeGlobalForwardingRule: computeGlobalForwardingRule,
 		ComputeForwardingRule:       computeForwardingRule,
 		ComputeDisk:                 computeDisk,
+		DNSManagedZone:              managedZoneDNS,
 		StorageBucket:               storageBucket,
 		SQLDatabaseInstance:         sqlDatabaseInstance,
 	}
@@ -279,6 +281,19 @@ func sqlDatabaseInstance(ctx context.Context, g *google, resourceType string, ta
 	resources := make([]provider.Resource, 0)
 	for _, instance := range instances {
 		r := provider.NewResource(instance.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func managedZoneDNS(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+	zones, err := g.gcpr.ListManagedZones(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list DNS managed zone from reader")
+	}
+	resources := make([]provider.Resource, 0)
+	for _, zone := range zones {
+		r := provider.NewResource(zone.Name, resourceType, g)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_storage_bucketgoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 378, 406}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 380, 401, 429}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_storage_bucketgoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -48,10 +48,12 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[308:338]: 11,
 	_ResourceTypeName[338:357]:      12,
 	_ResourceTypeLowerName[338:357]: 12,
-	_ResourceTypeName[357:378]:      13,
-	_ResourceTypeLowerName[357:378]: 13,
-	_ResourceTypeName[378:406]:      14,
-	_ResourceTypeLowerName[378:406]: 14,
+	_ResourceTypeName[357:380]:      13,
+	_ResourceTypeLowerName[357:380]: 13,
+	_ResourceTypeName[380:401]:      14,
+	_ResourceTypeLowerName[380:401]: 14,
+	_ResourceTypeName[401:429]:      15,
+	_ResourceTypeLowerName[401:429]: 15,
 }
 
 var _ResourceTypeNames = []string{
@@ -68,8 +70,9 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[271:308],
 	_ResourceTypeName[308:338],
 	_ResourceTypeName[338:357],
-	_ResourceTypeName[357:378],
-	_ResourceTypeName[378:406],
+	_ResourceTypeName[357:380],
+	_ResourceTypeName[380:401],
+	_ResourceTypeName[401:429],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 380, 401, 429}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 380, 401, 422, 450}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -52,8 +52,10 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[357:380]: 13,
 	_ResourceTypeName[380:401]:      14,
 	_ResourceTypeLowerName[380:401]: 14,
-	_ResourceTypeName[401:429]:      15,
-	_ResourceTypeLowerName[401:429]: 15,
+	_ResourceTypeName[401:422]:      15,
+	_ResourceTypeLowerName[401:422]: 15,
+	_ResourceTypeName[422:450]:      16,
+	_ResourceTypeLowerName[422:450]: 16,
 }
 
 var _ResourceTypeNames = []string{
@@ -72,7 +74,8 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[338:357],
 	_ResourceTypeName[357:380],
 	_ResourceTypeName[380:401],
-	_ResourceTypeName[401:429],
+	_ResourceTypeName[401:422],
+	_ResourceTypeName[422:450],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
Two new components:

- `RecordSet`: listing DNS records for a managed zone.
- `ManagedZone`: A ManagedZone is a resource that represents a DNS zone hosted by the Cloud DNS service.

The third one: `Policy`, is in beta.

`RecordSet` component is sligthly different from the others, since it needs to be feed by the `managedZones`, so this function need to be run after the `managedZones` fetching. 