### PR TITLE
ci: push tag before releasing artifacts

### DIFF
--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -275,6 +275,12 @@ jobs:
           params: { bump: final }
       - put: final-version
         params: { file: repo-version/version }
+      - put: ((branch))
+        resource: repo-((branch))
+        params:
+          repository: ((branch))
+          tag: repo-version/version
+          tag_prefix: v
 
   - name: release-((branch))
     serial: true


### PR DESCRIPTION
current artifacts are tagged with the wrong tag: 

```shell
$ docker run --rm cycloid/terracognita:v0.3.0 version
The current version is: v0.2.0-39-g9f5adfa
$ pacman -Qi terracognita | awk '/Version/ {print $3}'
1:0.3.0-1
$ terracognita version
The current version is: v0.2.0-39-g9f5adfa
```

tag was created with the GH release: we need to push it before generating artifacts.

I already refreshed the pipeline 