### PR TITLE
Provide filters as arg to resources instead of tags only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Changed
+
+- Provide filters to resource functions instead of tags only
+  ([PR #92](https://github.com/cycloidio/terracognita/pull/92))
+
 ## [0.4.0] _2020-03-31_
 
 ### Added
@@ -14,11 +19,6 @@
   ([Issue #40](https://github.com/cycloidio/terracognita/issues/40))
 - New AzureRM provider
   ([PR #88](https://github.com/cycloidio/terracognita/pull/88))
-
-### Changed
-
-- Provide filters to resource functions instead of tags only
-  ([PR #92](https://github.com/cycloidio/terracognita/pull/92))
 
 ## [0.3.0] _2020-01-02_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - New AzureRM provider
   ([PR #88](https://github.com/cycloidio/terracognita/pull/88))
 
+### Changed
+
+- Provide filters to resource functions instead of tags only
+  ([PR #92](https://github.com/cycloidio/terracognita/pull/92))
+
 ## [0.3.0] _2020-01-02_
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ The const is used to generate `aws/resourcetype_enumer.go`.
 3. Add the associated function to generate terraform codes.
 
 ```go
-func dbParameterGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func dbParameterGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	dbParameterGroups, err := a.awsr.GetDBParameterGroups(ctx, nil)
 
 	if err != nil {
@@ -302,7 +302,7 @@ You only need to find out if your component belongs to a `project` or a `project
 
 #### Build and test your component
 
-That's it ! You can now generate some code and build your binary: 
+That's it ! You can now generate some code and build your binary:
 
 ```shell
 $ make generate && make build

--- a/aws/cache.go
+++ b/aws/cache.go
@@ -4,19 +4,19 @@ import (
 	"context"
 
 	"github.com/cycloidio/terracognita/errcode"
+	"github.com/cycloidio/terracognita/filter"
 	"github.com/cycloidio/terracognita/provider"
-	"github.com/cycloidio/terracognita/tag"
 	"github.com/pkg/errors"
 )
 
-func cacheLoadBalancersV2(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheLoadBalancersV2(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = albs(ctx, a, rt, tags)
+		rs, err = albs(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -30,8 +30,8 @@ func cacheLoadBalancersV2(ctx context.Context, a *aws, rt string, tags []tag.Tag
 	return rs, nil
 }
 
-func getLoadBalancersV2Arns(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheLoadBalancersV2(ctx, a, rt, tags)
+func getLoadBalancersV2Arns(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheLoadBalancersV2(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +46,14 @@ func getLoadBalancersV2Arns(ctx context.Context, a *aws, rt string, tags []tag.T
 	return names, nil
 }
 
-func cacheLoadBalancersV2Listeners(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheLoadBalancersV2Listeners(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = albListeners(ctx, a, rt, tags)
+		rs, err = albListeners(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -67,8 +67,8 @@ func cacheLoadBalancersV2Listeners(ctx context.Context, a *aws, rt string, tags 
 	return rs, nil
 }
 
-func getLoadBalancersV2ListenersArns(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheLoadBalancersV2Listeners(ctx, a, rt, tags)
+func getLoadBalancersV2ListenersArns(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheLoadBalancersV2Listeners(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -83,14 +83,14 @@ func getLoadBalancersV2ListenersArns(ctx context.Context, a *aws, rt string, tag
 	return names, nil
 }
 
-func cacheIAMGroups(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheIAMGroups(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = iamGroups(ctx, a, rt, tags)
+		rs, err = iamGroups(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -104,8 +104,8 @@ func cacheIAMGroups(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]p
 	return rs, nil
 }
 
-func getIAMGroupNames(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheIAMGroups(ctx, a, rt, tags)
+func getIAMGroupNames(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheIAMGroups(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -120,14 +120,14 @@ func getIAMGroupNames(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([
 	return names, nil
 }
 
-func cacheIAMRoles(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheIAMRoles(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = iamRoles(ctx, a, rt, tags)
+		rs, err = iamRoles(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -141,8 +141,8 @@ func cacheIAMRoles(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]pr
 	return rs, nil
 }
 
-func getIAMRoleNames(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheIAMRoles(ctx, a, rt, tags)
+func getIAMRoleNames(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheIAMRoles(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -157,14 +157,14 @@ func getIAMRoleNames(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]
 	return names, nil
 }
 
-func cacheIAMUsers(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheIAMUsers(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = iamUsers(ctx, a, rt, tags)
+		rs, err = iamUsers(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -178,8 +178,8 @@ func cacheIAMUsers(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]pr
 	return rs, nil
 }
 
-func getIAMUserNames(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheIAMUsers(ctx, a, rt, tags)
+func getIAMUserNames(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheIAMUsers(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -194,14 +194,14 @@ func getIAMUserNames(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]
 	return names, nil
 }
 
-func cacheRoute53Zones(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheRoute53Zones(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = route53Zones(ctx, a, rt, tags)
+		rs, err = route53Zones(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -215,8 +215,8 @@ func cacheRoute53Zones(ctx context.Context, a *aws, rt string, tags []tag.Tag) (
 	return rs, nil
 }
 
-func getRoute53ZoneIDs(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheRoute53Zones(ctx, a, rt, tags)
+func getRoute53ZoneIDs(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheRoute53Zones(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -231,14 +231,14 @@ func getRoute53ZoneIDs(ctx context.Context, a *aws, rt string, tags []tag.Tag) (
 	return ids, nil
 }
 
-func cacheSESDomainIdentities(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheSESDomainIdentities(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = sesDomainIdentities(ctx, a, rt, tags)
+		rs, err = sesDomainIdentities(ctx, a, rt, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -252,8 +252,8 @@ func cacheSESDomainIdentities(ctx context.Context, a *aws, rt string, tags []tag
 	return rs, nil
 }
 
-func getSESDomainIdentityDomains(ctx context.Context, a *aws, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheSESDomainIdentities(ctx, a, rt, tags)
+func getSESDomainIdentityDomains(ctx context.Context, a *aws, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheSESDomainIdentities(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -69,7 +69,7 @@ func (a *aws) Resources(ctx context.Context, t string, f *filter.Filter) ([]prov
 		return nil, errors.Errorf("the resource %q it's not implemented", t)
 	}
 
-	resources, err := rfn(ctx, a, t, f.Tags)
+	resources, err := rfn(ctx, a, t, f)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while reading from resource %q", t)
 	}

--- a/aws/resources.go
+++ b/aws/resources.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/cycloidio/terracognita/filter"
 	"github.com/cycloidio/terracognita/provider"
-	"github.com/cycloidio/terracognita/tag"
 )
 
 // ResourceType is the type used to define all the Resources
@@ -105,7 +105,7 @@ const (
 	AutoscalingPolicy
 )
 
-type rtFn func(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
+type rtFn func(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error)
 
 var (
 	resources = map[ResourceType]rtFn{
@@ -184,9 +184,9 @@ func initializeResource(a *aws, ID, t string) (provider.Resource, error) {
 	return provider.NewResource(ID, t, a), nil
 }
 
-func instances(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func instances(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	var input = &ec2.DescribeInstancesInput{
-		Filters: toEC2Filters(tags),
+		Filters: toEC2Filters(filters),
 	}
 
 	instances, err := a.awsr.GetInstances(ctx, input)
@@ -208,9 +208,9 @@ func instances(ctx context.Context, a *aws, resourceType string, tags []tag.Tag)
 	return resources, nil
 }
 
-func vpcs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func vpcs(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	var input = &ec2.DescribeVpcsInput{
-		Filters: toEC2Filters(tags),
+		Filters: toEC2Filters(filters),
 	}
 
 	vpcs, err := a.awsr.GetVpcs(ctx, input)
@@ -230,9 +230,9 @@ func vpcs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]p
 	return resources, nil
 }
 
-//func amis(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+//func amis(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 //var input = &ec2.DescribeImagesInput{
-//Filters: toEC2Filters(tags),
+//Filters: toEC2Filters(filters),
 //}
 
 //images, err := a.awsr.GetOwnImages(ctx, input)
@@ -252,8 +252,12 @@ func vpcs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]p
 //return resources, nil
 //}
 
-func vpcPeeringConnections(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	vpcPeeringConnections, err := a.awsr.GetVpcPeeringConnections(ctx, nil)
+func vpcPeeringConnections(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	var input = &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: toEC2Filters(filters),
+	}
+
+	vpcPeeringConnections, err := a.awsr.GetVpcPeeringConnections(ctx, input)
 
 	if err != nil {
 		return nil, err
@@ -273,8 +277,12 @@ func vpcPeeringConnections(ctx context.Context, a *aws, resourceType string, tag
 	return resources, nil
 }
 
-func keyPairs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	keyPairs, err := a.awsr.GetKeyPairs(ctx, nil)
+func keyPairs(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	var input = &ec2.DescribeKeyPairsInput{
+		Filters: toEC2Filters(filters),
+	}
+
+	keyPairs, err := a.awsr.GetKeyPairs(ctx, input)
 
 	if err != nil {
 		return nil, err
@@ -294,9 +302,9 @@ func keyPairs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) 
 	return resources, nil
 }
 
-func securityGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func securityGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	var input = &ec2.DescribeSecurityGroupsInput{
-		Filters: toEC2Filters(tags),
+		Filters: toEC2Filters(filters),
 	}
 
 	sgs, err := a.awsr.GetSecurityGroups(ctx, input)
@@ -316,9 +324,9 @@ func securityGroups(ctx context.Context, a *aws, resourceType string, tags []tag
 	return resources, nil
 }
 
-func subnets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func subnets(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	var input = &ec2.DescribeSubnetsInput{
-		Filters: toEC2Filters(tags),
+		Filters: toEC2Filters(filters),
 	}
 
 	subnets, err := a.awsr.GetSubnets(ctx, input)
@@ -338,9 +346,9 @@ func subnets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) (
 	return resources, nil
 }
 
-func ebsVolumes(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func ebsVolumes(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	var input = &ec2.DescribeVolumesInput{
-		Filters: toEC2Filters(tags),
+		Filters: toEC2Filters(filters),
 	}
 
 	volumes, err := a.awsr.GetVolumes(ctx, input)
@@ -360,9 +368,9 @@ func ebsVolumes(ctx context.Context, a *aws, resourceType string, tags []tag.Tag
 	return resources, nil
 }
 
-//func ebsSnapshots(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+//func ebsSnapshots(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 //var input = &ec2.DescribeSnapshotsInput{
-//Filters: toEC2Filters(tags),
+//Filters: toEC2Filters(filters),
 //}
 
 //snapshots, err := a.awsr.GetOwnSnapshots(ctx, input)
@@ -382,7 +390,7 @@ func ebsVolumes(ctx context.Context, a *aws, resourceType string, tags []tag.Tag
 //return resources, nil
 //}
 
-func elasticacheClusters(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func elasticacheClusters(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	cacheClusters, err := a.awsr.GetElastiCacheClusters(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -400,7 +408,7 @@ func elasticacheClusters(ctx context.Context, a *aws, resourceType string, tags 
 	return resources, nil
 }
 
-func elbs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func elbs(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	lbs, err := a.awsr.GetLoadBalancers(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -418,7 +426,7 @@ func elbs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]p
 	return resources, nil
 }
 
-func albs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func albs(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	lbs, err := a.awsr.GetLoadBalancersV2(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -436,9 +444,8 @@ func albs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]p
 	return resources, nil
 }
 
-func albListeners(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-
-	ALBArns, err := getLoadBalancersV2Arns(ctx, a, ALB.String(), tags)
+func albListeners(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	ALBArns, err := getLoadBalancersV2Arns(ctx, a, ALB.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -467,9 +474,8 @@ func albListeners(ctx context.Context, a *aws, resourceType string, tags []tag.T
 	return resources, nil
 }
 
-func albListenerRules(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-
-	ALBListeners, err := getLoadBalancersV2ListenersArns(ctx, a, ALBListener.String(), tags)
+func albListenerRules(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	ALBListeners, err := getLoadBalancersV2ListenersArns(ctx, a, ALBListener.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -502,9 +508,8 @@ func albListenerRules(ctx context.Context, a *aws, resourceType string, tags []t
 	return resources, nil
 }
 
-func albListenerCertificates(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-
-	ALBListeners, err := getLoadBalancersV2ListenersArns(ctx, a, ALBListener.String(), tags)
+func albListenerCertificates(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	ALBListeners, err := getLoadBalancersV2ListenersArns(ctx, a, ALBListener.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +546,7 @@ func albListenerCertificates(ctx context.Context, a *aws, resourceType string, t
 	//return resources, nil
 }
 
-func albTargetGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func albTargetGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	albTargetGroups, err := a.awsr.GetLoadBalancersV2TargetGroups(ctx, nil)
 
 	if err != nil {
@@ -562,7 +567,7 @@ func albTargetGroups(ctx context.Context, a *aws, resourceType string, tags []ta
 	return resources, nil
 }
 
-func dbInstances(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func dbInstances(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	dbs, err := a.awsr.GetDBInstances(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -580,7 +585,7 @@ func dbInstances(ctx context.Context, a *aws, resourceType string, tags []tag.Ta
 	return resources, nil
 }
 
-func dbParameterGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func dbParameterGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	dbParameterGroups, err := a.awsr.GetDBParameterGroups(ctx, nil)
 
 	if err != nil {
@@ -601,7 +606,7 @@ func dbParameterGroups(ctx context.Context, a *aws, resourceType string, tags []
 	return resources, nil
 }
 
-func dbSubnetGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func dbSubnetGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	dbSubnetGroups, err := a.awsr.GetDBSubnetGroups(ctx, nil)
 
 	if err != nil {
@@ -622,7 +627,7 @@ func dbSubnetGroups(ctx context.Context, a *aws, resourceType string, tags []tag
 	return resources, nil
 }
 
-func s3Buckets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func s3Buckets(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	buckets, err := a.awsr.ListBuckets(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -640,7 +645,7 @@ func s3Buckets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag)
 	return resources, nil
 }
 
-func cloudfrontDistributions(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func cloudfrontDistributions(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	distributions, err := a.awsr.GetCloudFrontDistributions(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -658,7 +663,7 @@ func cloudfrontDistributions(ctx context.Context, a *aws, resourceType string, t
 	return resources, nil
 }
 
-func cloudfrontOriginAccessIdentities(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func cloudfrontOriginAccessIdentities(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	identitys, err := a.awsr.GetCloudFrontOriginAccessIdentities(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -676,7 +681,7 @@ func cloudfrontOriginAccessIdentities(ctx context.Context, a *aws, resourceType 
 	return resources, nil
 }
 
-func cloudfrontPublicKeys(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func cloudfrontPublicKeys(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	publicKeys, err := a.awsr.GetCloudFrontPublicKeys(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -694,7 +699,7 @@ func cloudfrontPublicKeys(ctx context.Context, a *aws, resourceType string, tags
 	return resources, nil
 }
 
-func cloudwatchMetricAlarms(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func cloudwatchMetricAlarms(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	alarms, err := a.awsr.GetAlarms(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -713,10 +718,9 @@ func cloudwatchMetricAlarms(ctx context.Context, a *aws, resourceType string, ta
 	return resources, nil
 }
 
-func iamAccessKeys(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-
+func iamAccessKeys(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	// Get the users list
-	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), tags)
+	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -746,7 +750,7 @@ func iamAccessKeys(ctx context.Context, a *aws, resourceType string, tags []tag.
 	return resources, nil
 }
 
-func iamAccountAliases(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamAccountAliases(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	accountAliases, err := a.awsr.GetAccountAliases(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -764,7 +768,7 @@ func iamAccountAliases(ctx context.Context, a *aws, resourceType string, tags []
 	return resources, nil
 }
 
-func iamAccountPasswordPolicy(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamAccountPasswordPolicy(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	// As it's for the full account we'll tell TF to fetch it directly with a "" id
 	r, err := initializeResource(a, "iam-account-password-policy", resourceType)
 	if err != nil {
@@ -773,7 +777,7 @@ func iamAccountPasswordPolicy(ctx context.Context, a *aws, resourceType string, 
 	return []provider.Resource{r}, nil
 }
 
-func iamGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	groups, err := a.awsr.GetGroups(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -791,8 +795,8 @@ func iamGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag)
 	return resources, nil
 }
 
-func iamGroupMemberships(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), tags)
+func iamGroupMemberships(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -813,8 +817,8 @@ func iamGroupMemberships(ctx context.Context, a *aws, resourceType string, tags 
 	return resources, nil
 }
 
-func iamGroupPolicies(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), tags)
+func iamGroupPolicies(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -843,8 +847,8 @@ func iamGroupPolicies(ctx context.Context, a *aws, resourceType string, tags []t
 	return resources, nil
 }
 
-func iamGroupPolicyAttachments(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), tags)
+func iamGroupPolicyAttachments(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -871,7 +875,7 @@ func iamGroupPolicyAttachments(ctx context.Context, a *aws, resourceType string,
 	return resources, nil
 }
 
-func iamInstanceProfiles(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamInstanceProfiles(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	instanceProfiles, err := a.awsr.GetInstanceProfiles(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -889,7 +893,7 @@ func iamInstanceProfiles(ctx context.Context, a *aws, resourceType string, tags 
 	return resources, nil
 }
 
-func iamOpenidConnectProviders(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamOpenidConnectProviders(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	openIDConnectProviders, err := a.awsr.GetOpenIDConnectProviders(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -907,7 +911,7 @@ func iamOpenidConnectProviders(ctx context.Context, a *aws, resourceType string,
 	return resources, nil
 }
 
-func iamPolicies(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamPolicies(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	input := &iam.ListPoliciesInput{
 		Scope: awsSDK.String("Local"),
 	}
@@ -928,7 +932,7 @@ func iamPolicies(ctx context.Context, a *aws, resourceType string, tags []tag.Ta
 	return resources, nil
 }
 
-func iamRoles(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamRoles(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	roles, err := a.awsr.GetRoles(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -946,8 +950,8 @@ func iamRoles(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) 
 	return resources, nil
 }
 
-func iamRolePolicies(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	roleNames, err := getIAMRoleNames(ctx, a, IAMRole.String(), tags)
+func iamRolePolicies(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	roleNames, err := getIAMRoleNames(ctx, a, IAMRole.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -974,8 +978,8 @@ func iamRolePolicies(ctx context.Context, a *aws, resourceType string, tags []ta
 	return resources, nil
 }
 
-func iamRolePolicyAttachments(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	roleNames, err := getIAMRoleNames(ctx, a, IAMRole.String(), tags)
+func iamRolePolicyAttachments(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	roleNames, err := getIAMRoleNames(ctx, a, IAMRole.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1006,7 @@ func iamRolePolicyAttachments(ctx context.Context, a *aws, resourceType string, 
 	return resources, nil
 }
 
-func iamSAMLProviders(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamSAMLProviders(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	samalProviders, err := a.awsr.GetSAMLProviders(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1020,7 +1024,7 @@ func iamSAMLProviders(ctx context.Context, a *aws, resourceType string, tags []t
 	return resources, nil
 }
 
-func iamServerCertificates(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamServerCertificates(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	serverCertificates, err := a.awsr.GetServerCertificates(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1038,7 +1042,7 @@ func iamServerCertificates(ctx context.Context, a *aws, resourceType string, tag
 	return resources, nil
 }
 
-func iamUsers(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func iamUsers(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	users, err := a.awsr.GetUsers(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1056,13 +1060,13 @@ func iamUsers(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) 
 	return resources, nil
 }
 
-func iamUserGroupMemberships(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), tags)
+func iamUserGroupMemberships(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), filters)
 	if err != nil {
 		return nil, err
 	}
 
-	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), tags)
+	groupNames, err := getIAMGroupNames(ctx, a, IAMGroup.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1080,8 +1084,8 @@ func iamUserGroupMemberships(ctx context.Context, a *aws, resourceType string, t
 	return resources, nil
 }
 
-func iamUserPolicies(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), tags)
+func iamUserPolicies(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1108,8 +1112,8 @@ func iamUserPolicies(ctx context.Context, a *aws, resourceType string, tags []ta
 	return resources, nil
 }
 
-func iamUserPolicyAttachments(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), tags)
+func iamUserPolicyAttachments(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1136,10 +1140,9 @@ func iamUserPolicyAttachments(ctx context.Context, a *aws, resourceType string, 
 	return resources, nil
 }
 
-func iamUserSSHKeys(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-
+func iamUserSSHKeys(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	// Get the users list
-	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), tags)
+	userNames, err := getIAMUserNames(ctx, a, IAMUser.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1167,7 +1170,8 @@ func iamUserSSHKeys(ctx context.Context, a *aws, resourceType string, tags []tag
 	return resources, nil
 }
 
-func route53DelegationSets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func route53DelegationSets(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+
 	r53DelegationSets, err := a.awsr.GetReusableDelegationSets(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1185,7 +1189,7 @@ func route53DelegationSets(ctx context.Context, a *aws, resourceType string, tag
 	return resources, nil
 }
 
-func route53HealthChecks(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func route53HealthChecks(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	r53HealthChecks, err := a.awsr.GetHealthChecks(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1203,7 +1207,7 @@ func route53HealthChecks(ctx context.Context, a *aws, resourceType string, tags 
 	return resources, nil
 }
 
-func route53QueryLogs(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func route53QueryLogs(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	r53QueryLogs, err := a.awsr.GetQueryLoggingConfigs(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1221,7 +1225,7 @@ func route53QueryLogs(ctx context.Context, a *aws, resourceType string, tags []t
 	return resources, nil
 }
 
-func route53Zones(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func route53Zones(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	r53Zones, err := a.awsr.GetHostedZones(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1239,8 +1243,8 @@ func route53Zones(ctx context.Context, a *aws, resourceType string, tags []tag.T
 	return resources, nil
 }
 
-func route53Records(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	zones, err := getRoute53ZoneIDs(ctx, a, Route53Zone.String(), tags)
+func route53Records(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	zones, err := getRoute53ZoneIDs(ctx, a, Route53Zone.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1271,8 +1275,8 @@ func route53Records(ctx context.Context, a *aws, resourceType string, tags []tag
 	return resources, nil
 }
 
-func route53ZoneAssociations(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	zones, err := getRoute53ZoneIDs(ctx, a, Route53Zone.String(), tags)
+func route53ZoneAssociations(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	zones, err := getRoute53ZoneIDs(ctx, a, Route53Zone.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1299,7 +1303,7 @@ func route53ZoneAssociations(ctx context.Context, a *aws, resourceType string, t
 	return resources, nil
 }
 
-func route53ResolverEndpoints(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func route53ResolverEndpoints(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	r53ResolverEndpoints, err := a.awsr.GetResolverEndpoints(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1317,7 +1321,7 @@ func route53ResolverEndpoints(ctx context.Context, a *aws, resourceType string, 
 	return resources, nil
 }
 
-func route53ResolverRuleAssociation(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func route53ResolverRuleAssociation(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	r53ResolverRuleAssociations, err := a.awsr.GetResolverRuleAssociations(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1335,7 +1339,7 @@ func route53ResolverRuleAssociation(ctx context.Context, a *aws, resourceType st
 	return resources, nil
 }
 
-func sesActiveReceiptRuleSets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesActiveReceiptRuleSets(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesActiveReceiptRuleSets, err := a.awsr.GetActiveReceiptRuleSet(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1353,7 +1357,7 @@ func sesActiveReceiptRuleSets(ctx context.Context, a *aws, resourceType string, 
 	return []provider.Resource{r}, nil
 }
 
-func sesDomainIdentities(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesDomainIdentities(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesDomainIdentities, err := a.awsr.GetIdentities(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1371,8 +1375,8 @@ func sesDomainIdentities(ctx context.Context, a *aws, resourceType string, tags 
 	return resources, nil
 }
 
-func sesDomainGeneral(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	domainNames, err := getSESDomainIdentityDomains(ctx, a, SESDomainIdentity.String(), tags)
+func sesDomainGeneral(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	domainNames, err := getSESDomainIdentityDomains(ctx, a, SESDomainIdentity.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1389,7 +1393,7 @@ func sesDomainGeneral(ctx context.Context, a *aws, resourceType string, tags []t
 	return resources, nil
 }
 
-func sesReceiptFilters(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesReceiptFilters(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesReceiptFilters, err := a.awsr.GetReceiptFilters(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1407,7 +1411,7 @@ func sesReceiptFilters(ctx context.Context, a *aws, resourceType string, tags []
 	return resources, nil
 }
 
-func sesReceiptRules(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesReceiptRules(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesActiveReceiptRuleSets, err := a.awsr.GetActiveReceiptRuleSet(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1425,7 +1429,7 @@ func sesReceiptRules(ctx context.Context, a *aws, resourceType string, tags []ta
 	return resources, nil
 }
 
-func sesReceiptRuleSets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesReceiptRuleSets(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesActiveReceiptRuleSets, err := a.awsr.GetActiveReceiptRuleSet(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1443,7 +1447,7 @@ func sesReceiptRuleSets(ctx context.Context, a *aws, resourceType string, tags [
 	return []provider.Resource{r}, nil
 }
 
-func sesConfigurationSets(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesConfigurationSets(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesConfigurationSets, err := a.awsr.GetConfigurationSets(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1461,8 +1465,8 @@ func sesConfigurationSets(ctx context.Context, a *aws, resourceType string, tags
 	return resources, nil
 }
 
-func sesIdentityNotificationTopics(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	domainNames, err := getSESDomainIdentityDomains(ctx, a, SESDomainIdentity.String(), tags)
+func sesIdentityNotificationTopics(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	domainNames, err := getSESDomainIdentityDomains(ctx, a, SESDomainIdentity.String(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1505,7 +1509,7 @@ func sesIdentityNotificationTopics(ctx context.Context, a *aws, resourceType str
 	return resources, nil
 }
 
-func sesTemplates(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func sesTemplates(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	sesTemplates, err := a.awsr.GetTemplates(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -1523,7 +1527,7 @@ func sesTemplates(ctx context.Context, a *aws, resourceType string, tags []tag.T
 	return resources, nil
 }
 
-func launchConfigurations(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func launchConfigurations(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	launchConfigurations, err := a.awsr.GetLaunchConfigurations(ctx, nil)
 
 	if err != nil {
@@ -1544,8 +1548,12 @@ func launchConfigurations(ctx context.Context, a *aws, resourceType string, tags
 	return resources, nil
 }
 
-func launchTemplates(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	launchTemplates, err := a.awsr.GetLaunchTemplates(ctx, nil)
+func launchTemplates(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	var input = &ec2.DescribeLaunchTemplatesInput{
+		Filters: toEC2Filters(filters),
+	}
+
+	launchTemplates, err := a.awsr.GetLaunchTemplates(ctx, input)
 
 	if err != nil {
 		return nil, err
@@ -1565,7 +1573,7 @@ func launchTemplates(ctx context.Context, a *aws, resourceType string, tags []ta
 	return resources, nil
 }
 
-func autoscalingGroups(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func autoscalingGroups(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	autoscalingGroups, err := a.awsr.GetAutoScalingGroups(ctx, nil)
 
 	if err != nil {
@@ -1586,7 +1594,7 @@ func autoscalingGroups(ctx context.Context, a *aws, resourceType string, tags []
 	return resources, nil
 }
 
-func autoscalingPolicies(ctx context.Context, a *aws, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func autoscalingPolicies(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	autoscalingPolicies, err := a.awsr.GetAutoScalingPolicies(ctx, nil)
 
 	if err != nil {
@@ -1607,15 +1615,16 @@ func autoscalingPolicies(ctx context.Context, a *aws, resourceType string, tags 
 	return resources, nil
 }
 
-func toEC2Filters(tags []tag.Tag) []*ec2.Filter {
+func toEC2Filters(filters *filter.Filter) []*ec2.Filter {
+	tags := filters.Tags
 	if len(tags) == 0 {
 		return nil
 	}
-	filters := make([]*ec2.Filter, 0, len(tags))
+	filtersEc2 := make([]*ec2.Filter, 0, len(tags))
 
 	for _, t := range tags {
-		filters = append(filters, t.ToEC2Filter())
+		filtersEc2 = append(filtersEc2, t.ToEC2Filter())
 	}
 
-	return filters
+	return filtersEc2
 }

--- a/azurerm/cache.go
+++ b/azurerm/cache.go
@@ -4,19 +4,19 @@ import (
 	"context"
 
 	"github.com/cycloidio/terracognita/errcode"
+	"github.com/cycloidio/terracognita/filter"
 	"github.com/cycloidio/terracognita/provider"
-	"github.com/cycloidio/terracognita/tag"
 	"github.com/pkg/errors"
 )
 
-func cacheVirtualNetworks(ctx context.Context, a *azurerm, rt string, tags []tag.Tag) ([]provider.Resource, error) {
+func cacheVirtualNetworks(ctx context.Context, a *azurerm, rt string, filters *filter.Filter) ([]provider.Resource, error) {
 	rs, err := a.cache.Get(rt)
 	if err != nil {
 		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
 			return nil, errors.WithStack(err)
 		}
 
-		rs, err = virtualNetworks(ctx, a, rt, tags)
+		rs, err = virtualNetworks(ctx, a, rt, filters)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get virtual networks")
 		}
@@ -30,8 +30,8 @@ func cacheVirtualNetworks(ctx context.Context, a *azurerm, rt string, tags []tag
 	return rs, nil
 }
 
-func getVirtualNetworkNames(ctx context.Context, a *azurerm, rt string, tags []tag.Tag) ([]string, error) {
-	rs, err := cacheVirtualNetworks(ctx, a, rt, tags)
+func getVirtualNetworkNames(ctx context.Context, a *azurerm, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheVirtualNetworks(ctx, a, rt, filters)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -84,7 +84,7 @@ func (a *azurerm) Resources(ctx context.Context, t string, f *filter.Filter) ([]
 		return nil, errors.Errorf("the resource %q it's not implemented", t)
 	}
 
-	resources, err := rfn(ctx, a, t, f.Tags)
+	resources, err := rfn(ctx, a, t, f)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while reading from resource %q", t)
 	}

--- a/azurerm/resources.go
+++ b/azurerm/resources.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cycloidio/terracognita/filter"
 	"github.com/cycloidio/terracognita/provider"
-	"github.com/cycloidio/terracognita/tag"
 )
 
 // ResourceType is the type used to define all the Resources
@@ -24,7 +24,7 @@ const (
 	VirtualMachineScaleSet
 )
 
-type rtFn func(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
+type rtFn func(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error)
 
 var (
 	resources = map[ResourceType]rtFn{
@@ -38,14 +38,14 @@ var (
 	}
 )
 
-func resourceGroup(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func resourceGroup(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	resourceGroup := a.azurer.GetResourceGroup()
 	r := provider.NewResource(*resourceGroup.ID, resourceType, a)
 	resources := []provider.Resource{r}
 	return resources, nil
 }
 
-func virtualMachines(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func virtualMachines(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	virtualMachines, err := a.azurer.ListVirtualMachines(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list virtual machines from reader")
@@ -58,7 +58,7 @@ func virtualMachines(ctx context.Context, a *azurerm, resourceType string, tags 
 	return resources, nil
 }
 
-func virtualNetworks(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func virtualNetworks(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	virtualNetworks, err := a.azurer.ListVirtualNetworks(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list virtual networks from reader")
@@ -76,8 +76,8 @@ func virtualNetworks(ctx context.Context, a *azurerm, resourceType string, tags 
 	return resources, nil
 }
 
-func subnets(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	virtualNetworkNames, err := getVirtualNetworkNames(ctx, a, resourceType, tags)
+func subnets(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	virtualNetworkNames, err := getVirtualNetworkNames(ctx, a, resourceType, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list virtual networks from cache")
 	}
@@ -95,7 +95,7 @@ func subnets(ctx context.Context, a *azurerm, resourceType string, tags []tag.Ta
 	return resources, nil
 }
 
-func networkInterfaces(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func networkInterfaces(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	networkInterfaces, err := a.azurer.ListInterfaces(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list network interfaces from reader")
@@ -108,7 +108,7 @@ func networkInterfaces(ctx context.Context, a *azurerm, resourceType string, tag
 	return resources, nil
 }
 
-func networkSecurityGroups(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func networkSecurityGroups(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	securityGroups, err := a.azurer.ListSecurityGroups(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list network security groups from reader")
@@ -121,7 +121,7 @@ func networkSecurityGroups(ctx context.Context, a *azurerm, resourceType string,
 	return resources, nil
 }
 
-func virtualMachineScaleSets(ctx context.Context, a *azurerm, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func virtualMachineScaleSets(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	virtualMachineScaleSets, err := a.azurer.ListVirtualMachineScaleSets(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list virtual machines scale sets from reader")

--- a/azurerm/resourcetype_enumer.go
+++ b/azurerm/resourcetype_enumer.go
@@ -19,36 +19,23 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-// An "invalid array index" compiler error signifies that the constant values have changed.
-// Re-run the stringer command to generate them again.
-func _ResourceTypeNoOp() {
-	var x [1]struct{}
-	_ = x[ResourceGroup-(0)]
-	_ = x[VirtualMachine-(1)]
-	_ = x[VirtualNetwork-(2)]
-	_ = x[Subnet-(3)]
-	_ = x[NetworkInterface-(4)]
-	_ = x[NetworkSecurityGroup-(5)]
-	_ = x[VirtualMachineScaleSet-(6)]
-}
-
-var _ResourceTypeValues = []ResourceType{ResourceGroup, VirtualMachine, VirtualNetwork, Subnet, NetworkInterface, NetworkSecurityGroup, VirtualMachineScaleSet}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
-	_ResourceTypeName[0:22]:         ResourceGroup,
-	_ResourceTypeLowerName[0:22]:    ResourceGroup,
-	_ResourceTypeName[22:45]:        VirtualMachine,
-	_ResourceTypeLowerName[22:45]:   VirtualMachine,
-	_ResourceTypeName[45:68]:        VirtualNetwork,
-	_ResourceTypeLowerName[45:68]:   VirtualNetwork,
-	_ResourceTypeName[68:82]:        Subnet,
-	_ResourceTypeLowerName[68:82]:   Subnet,
-	_ResourceTypeName[82:107]:       NetworkInterface,
-	_ResourceTypeLowerName[82:107]:  NetworkInterface,
-	_ResourceTypeName[107:137]:      NetworkSecurityGroup,
-	_ResourceTypeLowerName[107:137]: NetworkSecurityGroup,
-	_ResourceTypeName[137:170]:      VirtualMachineScaleSet,
-	_ResourceTypeLowerName[137:170]: VirtualMachineScaleSet,
+	_ResourceTypeName[0:22]:         0,
+	_ResourceTypeLowerName[0:22]:    0,
+	_ResourceTypeName[22:45]:        1,
+	_ResourceTypeLowerName[22:45]:   1,
+	_ResourceTypeName[45:68]:        2,
+	_ResourceTypeLowerName[45:68]:   2,
+	_ResourceTypeName[68:82]:        3,
+	_ResourceTypeLowerName[68:82]:   3,
+	_ResourceTypeName[82:107]:       4,
+	_ResourceTypeLowerName[82:107]:  4,
+	_ResourceTypeName[107:137]:      5,
+	_ResourceTypeLowerName[107:137]: 5,
+	_ResourceTypeName[137:170]:      6,
+	_ResourceTypeLowerName[137:170]: 6,
 }
 
 var _ResourceTypeNames = []string{

--- a/google/provider.go
+++ b/google/provider.go
@@ -74,7 +74,7 @@ func (g *google) Resources(ctx context.Context, t string, f *filter.Filter) ([]p
 		return nil, errors.Errorf("the resource %q it's not implemented", t)
 	}
 
-	resources, err := rfn(ctx, g, t, f.Tags)
+	resources, err := rfn(ctx, g, t, f)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while reading from resource %q", t)
 	}

--- a/google/resources.go
+++ b/google/resources.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cycloidio/terracognita/filter"
 	"github.com/cycloidio/terracognita/provider"
-	"github.com/cycloidio/terracognita/tag"
 )
 
 // ResourceType is the type used to define all the Resources
@@ -40,7 +40,7 @@ const (
 	SQLDatabaseInstance
 )
 
-type rtFn func(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error)
+type rtFn func(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error)
 
 var (
 	resources = map[ResourceType]rtFn{
@@ -64,17 +64,17 @@ var (
 	}
 )
 
-func initializeFilter(tags []tag.Tag) string {
+func initializeFilter(filters *filter.Filter) string {
 	var b bytes.Buffer
-	for _, t := range tags {
+	for _, t := range filters.Tags {
 		// if multiple tags, we suppose it's a "AND" operation
 		b.WriteString(fmt.Sprintf("(labels.%s=%s) ", t.Name, t.Value))
 	}
 	return b.String()
 }
 
-func computeInstance(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeInstance(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	instancesList, err := g.gcpr.ListInstances(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list instances from reader")
@@ -89,8 +89,8 @@ func computeInstance(ctx context.Context, g *google, resourceType string, tags [
 	return resources, nil
 }
 
-func computeFirewall(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeFirewall(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	firewalls, err := g.gcpr.ListFirewalls(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list firewalls from reader")
@@ -103,8 +103,8 @@ func computeFirewall(ctx context.Context, g *google, resourceType string, tags [
 	return resources, nil
 }
 
-func computeNetwork(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeNetwork(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	networks, err := g.gcpr.ListNetworks(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list networks from reader")
@@ -117,8 +117,8 @@ func computeNetwork(ctx context.Context, g *google, resourceType string, tags []
 	return resources, nil
 }
 
-func computeHealthCheck(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeHealthCheck(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	checks, err := g.gcpr.ListHealthChecks(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list health checks from reader")
@@ -131,8 +131,8 @@ func computeHealthCheck(ctx context.Context, g *google, resourceType string, tag
 	return resources, nil
 }
 
-func computeInstanceGroup(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeInstanceGroup(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	instanceGroups, err := g.gcpr.ListInstanceGroups(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list instance groups from reader")
@@ -147,8 +147,8 @@ func computeInstanceGroup(ctx context.Context, g *google, resourceType string, t
 	return resources, nil
 }
 
-func computeBackendService(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeBackendService(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	backends, err := g.gcpr.ListBackendServices(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list backend services from reader")
@@ -161,8 +161,8 @@ func computeBackendService(ctx context.Context, g *google, resourceType string, 
 	return resources, nil
 }
 
-func computeURLMap(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeURLMap(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	maps, err := g.gcpr.ListURLMaps(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list URL maps from reader")
@@ -175,8 +175,8 @@ func computeURLMap(ctx context.Context, g *google, resourceType string, tags []t
 	return resources, nil
 }
 
-func computeTargetHTTPProxy(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeTargetHTTPProxy(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	targets, err := g.gcpr.ListTargetHTTPProxies(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list target http proxies from reader")
@@ -189,8 +189,8 @@ func computeTargetHTTPProxy(ctx context.Context, g *google, resourceType string,
 	return resources, nil
 }
 
-func computeTargetHTTPSProxy(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeTargetHTTPSProxy(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	targets, err := g.gcpr.ListTargetHTTPSProxies(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list target https proxies from reader")
@@ -203,8 +203,8 @@ func computeTargetHTTPSProxy(ctx context.Context, g *google, resourceType string
 	return resources, nil
 }
 
-func computeSSLCertificate(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeSSLCertificate(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	certs, err := g.gcpr.ListSSLCertificates(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list SSL certificates from reader")
@@ -217,8 +217,8 @@ func computeSSLCertificate(ctx context.Context, g *google, resourceType string, 
 	return resources, nil
 }
 
-func computeGlobalForwardingRule(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeGlobalForwardingRule(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	rules, err := g.gcpr.ListGlobalForwardingRules(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
@@ -231,8 +231,8 @@ func computeGlobalForwardingRule(ctx context.Context, g *google, resourceType st
 	return resources, nil
 }
 
-func computeForwardingRule(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeForwardingRule(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	rules, err := g.gcpr.ListForwardingRules(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
@@ -245,8 +245,8 @@ func computeForwardingRule(ctx context.Context, g *google, resourceType string, 
 	return resources, nil
 }
 
-func computeDisk(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func computeDisk(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	disksList, err := g.gcpr.ListDisks(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list disks from reader")
@@ -261,7 +261,7 @@ func computeDisk(ctx context.Context, g *google, resourceType string, tags []tag
 	return resources, nil
 }
 
-func storageBucket(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func storageBucket(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	rules, err := g.gcpr.ListBuckets(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
@@ -274,8 +274,8 @@ func storageBucket(ctx context.Context, g *google, resourceType string, tags []t
 	return resources, nil
 }
 
-func sqlDatabaseInstance(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	f := initializeFilter(tags)
+func sqlDatabaseInstance(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
 	instances, err := g.gcpr.ListStorageInstances(ctx, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list sql storage instances rules from reader")
@@ -288,7 +288,7 @@ func sqlDatabaseInstance(ctx context.Context, g *google, resourceType string, ta
 	return resources, nil
 }
 
-func managedZoneDNS(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
+func managedZoneDNS(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
 	zones, err := g.gcpr.ListManagedZones(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list DNS managed zone from reader")
@@ -301,8 +301,8 @@ func managedZoneDNS(ctx context.Context, g *google, resourceType string, tags []
 	return resources, nil
 }
 
-func recordSetDNS(ctx context.Context, g *google, resourceType string, tags []tag.Tag) ([]provider.Resource, error) {
-	managedZones, err := managedZoneDNS(ctx, g, resourceType, tags)
+func recordSetDNS(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	managedZones, err := managedZoneDNS(ctx, g, resourceType, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to previously fetch managed zones")
 	}


### PR DESCRIPTION
Provide filters to resource functions. It will help to have more intelligence
between filtered resources.

For example 2 terraform resources can import the same element. If the 2
resources are runs, it doesn't make sense to write 2 time the same element.
