### PR TITLE
google: add CDN resource + IAM policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- google resources: `google_compute_backend_bucket`, `google_project_iam_custom_role`, `google_storage_bucket_iam_policy`, `google_compute_instance_iam_policy`
+  ([PR #97](https://github.com/cycloidio/terracognita/pull/97))
+
 ### Changed
 
 - Provide filters to resource functions instead of tags only

--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -11,6 +11,7 @@ import (
 
 var functions = []Function{
 	Function{Resource: "BackendService", Zone: false},
+	Function{Resource: "BackendBucket"},
 	Function{Resource: "Bucket", NoFilter: true, API: "storage", ResourceList: "Buckets"},
 	Function{Resource: "DatabaseInstance", Name: "StorageInstances", API: "sqladmin", ResourceList: "InstancesListResponse", ServiceName: "Instances"},
 	Function{Resource: "Disk", Zone: true},

--- a/google/cmd/generate.go
+++ b/google/cmd/generate.go
@@ -10,22 +10,22 @@ import (
 )
 
 var functions = []Function{
-	Function{Resource: "Instance", Zone: true},
-	Function{Resource: "Firewall", Zone: false},
-	Function{Resource: "Network", Zone: false},
-	Function{Resource: "InstanceGroup", Zone: true},
 	Function{Resource: "BackendService", Zone: false},
-	Function{Resource: "HealthCheck", Zone: false},
-	Function{Resource: "UrlMap", Zone: false, Name: "URLMaps"},
-	Function{Resource: "TargetHttpProxy", Zone: false, Name: "TargetHTTPProxies", ServiceName: "TargetHttpProxies"},
-	Function{Resource: "TargetHttpsProxy", Zone: false, Name: "TargetHTTPSProxies", ServiceName: "TargetHttpsProxies"},
-	Function{Resource: "SslCertificate", Zone: false, Name: "SSLCertificates"},
-	Function{Resource: "ForwardingRule", Zone: false, Name: "GlobalForwardingRules", ServiceName: "GlobalForwardingRules"},
-	Function{Resource: "ForwardingRule", Region: true},
-	Function{Resource: "Disk", Zone: true},
 	Function{Resource: "Bucket", NoFilter: true, API: "storage", ResourceList: "Buckets"},
 	Function{Resource: "DatabaseInstance", Name: "StorageInstances", API: "sqladmin", ResourceList: "InstancesListResponse", ServiceName: "Instances"},
+	Function{Resource: "Disk", Zone: true},
+	Function{Resource: "Firewall", Zone: false},
+	Function{Resource: "ForwardingRule", Zone: false, Name: "GlobalForwardingRules", ServiceName: "GlobalForwardingRules"},
+	Function{Resource: "ForwardingRule", Region: true},
+	Function{Resource: "HealthCheck", Zone: false},
+	Function{Resource: "Instance", Zone: true},
+	Function{Resource: "InstanceGroup", Zone: true},
 	Function{Resource: "ManagedZone", API: "dns", ResourceList: "ManagedZonesListResponse", NoFilter: true, ItemName: "ManagedZones"},
+	Function{Resource: "Network", Zone: false},
+	Function{Resource: "SslCertificate", Zone: false, Name: "SSLCertificates"},
+	Function{Resource: "TargetHttpProxy", Zone: false, Name: "TargetHTTPProxies", ServiceName: "TargetHttpProxies"},
+	Function{Resource: "TargetHttpsProxy", Zone: false, Name: "TargetHTTPSProxies", ServiceName: "TargetHttpsProxies"},
+	Function{Resource: "UrlMap", Zone: false, Name: "URLMaps"},
 }
 
 func main() {

--- a/google/reader.go
+++ b/google/reader.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 	"google.golang.org/api/storage/v1"
@@ -21,6 +22,7 @@ type GCPReader struct {
 	storage    *storage.Service
 	sqladmin   *sqladmin.Service
 	dns        *dns.Service
+	iam        *iam.Service
 	project    string
 	region     string
 	zones      []string
@@ -49,6 +51,10 @@ func NewGcpReader(ctx context.Context, maxResults uint64, project, region, crede
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create sqladmin service")
 	}
+	i, err := iam.NewService(ctx, option.WithCredentialsFile(credentials))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create iam service")
+	}
 	return &GCPReader{
 		compute:    comp,
 		storage:    storage,
@@ -56,6 +62,7 @@ func NewGcpReader(ctx context.Context, maxResults uint64, project, region, crede
 		project:    project,
 		region:     region,
 		dns:        d,
+		iam:        i,
 		zones:      []string{},
 		maxResults: maxResults,
 	}, nil

--- a/google/reader_generated.go
+++ b/google/reader_generated.go
@@ -12,29 +12,94 @@ import (
 	"google.golang.org/api/storage/v1"
 )
 
-// ListInstances returns a list of Instances within a project and a zone
-func (r *GCPReader) ListInstances(ctx context.Context, filter string) (map[string][]compute.Instance, error) {
-	service := compute.NewInstancesService(r.compute)
+// ListBackendServices returns a list of BackendServices within a project
+func (r *GCPReader) ListBackendServices(ctx context.Context, filter string) ([]compute.BackendService, error) {
+	service := compute.NewBackendServicesService(r.compute)
 
-	list := make(map[string][]compute.Instance)
+	resources := make([]compute.BackendService, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.BackendServiceList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute BackendService from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListBuckets returns a list of Buckets within a project
+func (r *GCPReader) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
+	service := storage.NewBucketsService(r.storage)
+
+	resources := make([]storage.Bucket, 0)
+
+	if err := service.List(r.project).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *storage.Buckets) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list storage Bucket from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListStorageInstances returns a list of StorageInstances within a project
+func (r *GCPReader) ListStorageInstances(ctx context.Context, filter string) ([]sqladmin.DatabaseInstance, error) {
+	service := sqladmin.NewInstancesService(r.sqladmin)
+
+	resources := make([]sqladmin.DatabaseInstance, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *sqladmin.InstancesListResponse) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list sqladmin DatabaseInstance from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListDisks returns a list of Disks within a project and a zone
+func (r *GCPReader) ListDisks(ctx context.Context, filter string) (map[string][]compute.Disk, error) {
+	service := compute.NewDisksService(r.compute)
+
+	list := make(map[string][]compute.Disk)
 	zones, err := r.getZones()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get zones in region")
 	}
 	for _, zone := range zones {
 
-		resources := make([]compute.Instance, 0)
+		resources := make([]compute.Disk, 0)
 
 		if err := service.List(r.project, zone).
 			Filter(filter).
 			MaxResults(int64(r.maxResults)).
-			Pages(ctx, func(list *compute.InstanceList) error {
+			Pages(ctx, func(list *compute.DiskList) error {
 				for _, res := range list.Items {
 					resources = append(resources, *res)
 				}
 				return nil
 			}); err != nil {
-			return nil, errors.Wrap(err, "unable to list compute Instance from google APIs")
+			return nil, errors.Wrap(err, "unable to list compute Disk from google APIs")
 		}
 
 		list[zone] = resources
@@ -59,191 +124,6 @@ func (r *GCPReader) ListFirewalls(ctx context.Context, filter string) ([]compute
 			return nil
 		}); err != nil {
 		return nil, errors.Wrap(err, "unable to list compute Firewall from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListNetworks returns a list of Networks within a project
-func (r *GCPReader) ListNetworks(ctx context.Context, filter string) ([]compute.Network, error) {
-	service := compute.NewNetworksService(r.compute)
-
-	resources := make([]compute.Network, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.NetworkList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute Network from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListInstanceGroups returns a list of InstanceGroups within a project and a zone
-func (r *GCPReader) ListInstanceGroups(ctx context.Context, filter string) (map[string][]compute.InstanceGroup, error) {
-	service := compute.NewInstanceGroupsService(r.compute)
-
-	list := make(map[string][]compute.InstanceGroup)
-	zones, err := r.getZones()
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get zones in region")
-	}
-	for _, zone := range zones {
-
-		resources := make([]compute.InstanceGroup, 0)
-
-		if err := service.List(r.project, zone).
-			Filter(filter).
-			MaxResults(int64(r.maxResults)).
-			Pages(ctx, func(list *compute.InstanceGroupList) error {
-				for _, res := range list.Items {
-					resources = append(resources, *res)
-				}
-				return nil
-			}); err != nil {
-			return nil, errors.Wrap(err, "unable to list compute InstanceGroup from google APIs")
-		}
-
-		list[zone] = resources
-	}
-	return list, nil
-
-}
-
-// ListBackendServices returns a list of BackendServices within a project
-func (r *GCPReader) ListBackendServices(ctx context.Context, filter string) ([]compute.BackendService, error) {
-	service := compute.NewBackendServicesService(r.compute)
-
-	resources := make([]compute.BackendService, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.BackendServiceList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute BackendService from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListHealthChecks returns a list of HealthChecks within a project
-func (r *GCPReader) ListHealthChecks(ctx context.Context, filter string) ([]compute.HealthCheck, error) {
-	service := compute.NewHealthChecksService(r.compute)
-
-	resources := make([]compute.HealthCheck, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.HealthCheckList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute HealthCheck from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListURLMaps returns a list of URLMaps within a project
-func (r *GCPReader) ListURLMaps(ctx context.Context, filter string) ([]compute.UrlMap, error) {
-	service := compute.NewUrlMapsService(r.compute)
-
-	resources := make([]compute.UrlMap, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.UrlMapList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute UrlMap from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListTargetHTTPProxies returns a list of TargetHTTPProxies within a project
-func (r *GCPReader) ListTargetHTTPProxies(ctx context.Context, filter string) ([]compute.TargetHttpProxy, error) {
-	service := compute.NewTargetHttpProxiesService(r.compute)
-
-	resources := make([]compute.TargetHttpProxy, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.TargetHttpProxyList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute TargetHttpProxy from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListTargetHTTPSProxies returns a list of TargetHTTPSProxies within a project
-func (r *GCPReader) ListTargetHTTPSProxies(ctx context.Context, filter string) ([]compute.TargetHttpsProxy, error) {
-	service := compute.NewTargetHttpsProxiesService(r.compute)
-
-	resources := make([]compute.TargetHttpsProxy, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.TargetHttpsProxyList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute TargetHttpsProxy from google APIs")
-	}
-
-	return resources, nil
-
-}
-
-// ListSSLCertificates returns a list of SSLCertificates within a project
-func (r *GCPReader) ListSSLCertificates(ctx context.Context, filter string) ([]compute.SslCertificate, error) {
-	service := compute.NewSslCertificatesService(r.compute)
-
-	resources := make([]compute.SslCertificate, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *compute.SslCertificateList) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list compute SslCertificate from google APIs")
 	}
 
 	return resources, nil
@@ -294,29 +174,51 @@ func (r *GCPReader) ListForwardingRules(ctx context.Context, filter string) ([]c
 
 }
 
-// ListDisks returns a list of Disks within a project and a zone
-func (r *GCPReader) ListDisks(ctx context.Context, filter string) (map[string][]compute.Disk, error) {
-	service := compute.NewDisksService(r.compute)
+// ListHealthChecks returns a list of HealthChecks within a project
+func (r *GCPReader) ListHealthChecks(ctx context.Context, filter string) ([]compute.HealthCheck, error) {
+	service := compute.NewHealthChecksService(r.compute)
 
-	list := make(map[string][]compute.Disk)
+	resources := make([]compute.HealthCheck, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.HealthCheckList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute HealthCheck from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListInstances returns a list of Instances within a project and a zone
+func (r *GCPReader) ListInstances(ctx context.Context, filter string) (map[string][]compute.Instance, error) {
+	service := compute.NewInstancesService(r.compute)
+
+	list := make(map[string][]compute.Instance)
 	zones, err := r.getZones()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get zones in region")
 	}
 	for _, zone := range zones {
 
-		resources := make([]compute.Disk, 0)
+		resources := make([]compute.Instance, 0)
 
 		if err := service.List(r.project, zone).
 			Filter(filter).
 			MaxResults(int64(r.maxResults)).
-			Pages(ctx, func(list *compute.DiskList) error {
+			Pages(ctx, func(list *compute.InstanceList) error {
 				for _, res := range list.Items {
 					resources = append(resources, *res)
 				}
 				return nil
 			}); err != nil {
-			return nil, errors.Wrap(err, "unable to list compute Disk from google APIs")
+			return nil, errors.Wrap(err, "unable to list compute Instance from google APIs")
 		}
 
 		list[zone] = resources
@@ -325,46 +227,34 @@ func (r *GCPReader) ListDisks(ctx context.Context, filter string) (map[string][]
 
 }
 
-// ListBuckets returns a list of Buckets within a project
-func (r *GCPReader) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
-	service := storage.NewBucketsService(r.storage)
+// ListInstanceGroups returns a list of InstanceGroups within a project and a zone
+func (r *GCPReader) ListInstanceGroups(ctx context.Context, filter string) (map[string][]compute.InstanceGroup, error) {
+	service := compute.NewInstanceGroupsService(r.compute)
 
-	resources := make([]storage.Bucket, 0)
-
-	if err := service.List(r.project).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *storage.Buckets) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list storage Bucket from google APIs")
+	list := make(map[string][]compute.InstanceGroup)
+	zones, err := r.getZones()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get zones in region")
 	}
+	for _, zone := range zones {
 
-	return resources, nil
+		resources := make([]compute.InstanceGroup, 0)
 
-}
+		if err := service.List(r.project, zone).
+			Filter(filter).
+			MaxResults(int64(r.maxResults)).
+			Pages(ctx, func(list *compute.InstanceGroupList) error {
+				for _, res := range list.Items {
+					resources = append(resources, *res)
+				}
+				return nil
+			}); err != nil {
+			return nil, errors.Wrap(err, "unable to list compute InstanceGroup from google APIs")
+		}
 
-// ListStorageInstances returns a list of StorageInstances within a project
-func (r *GCPReader) ListStorageInstances(ctx context.Context, filter string) ([]sqladmin.DatabaseInstance, error) {
-	service := sqladmin.NewInstancesService(r.sqladmin)
-
-	resources := make([]sqladmin.DatabaseInstance, 0)
-
-	if err := service.List(r.project).
-		Filter(filter).
-		MaxResults(int64(r.maxResults)).
-		Pages(ctx, func(list *sqladmin.InstancesListResponse) error {
-			for _, res := range list.Items {
-				resources = append(resources, *res)
-			}
-			return nil
-		}); err != nil {
-		return nil, errors.Wrap(err, "unable to list sqladmin DatabaseInstance from google APIs")
+		list[zone] = resources
 	}
-
-	return resources, nil
+	return list, nil
 
 }
 
@@ -383,6 +273,116 @@ func (r *GCPReader) ListManagedZones(ctx context.Context) ([]dns.ManagedZone, er
 			return nil
 		}); err != nil {
 		return nil, errors.Wrap(err, "unable to list dns ManagedZone from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListNetworks returns a list of Networks within a project
+func (r *GCPReader) ListNetworks(ctx context.Context, filter string) ([]compute.Network, error) {
+	service := compute.NewNetworksService(r.compute)
+
+	resources := make([]compute.Network, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.NetworkList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute Network from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListSSLCertificates returns a list of SSLCertificates within a project
+func (r *GCPReader) ListSSLCertificates(ctx context.Context, filter string) ([]compute.SslCertificate, error) {
+	service := compute.NewSslCertificatesService(r.compute)
+
+	resources := make([]compute.SslCertificate, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.SslCertificateList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute SslCertificate from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListTargetHTTPProxies returns a list of TargetHTTPProxies within a project
+func (r *GCPReader) ListTargetHTTPProxies(ctx context.Context, filter string) ([]compute.TargetHttpProxy, error) {
+	service := compute.NewTargetHttpProxiesService(r.compute)
+
+	resources := make([]compute.TargetHttpProxy, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.TargetHttpProxyList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute TargetHttpProxy from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListTargetHTTPSProxies returns a list of TargetHTTPSProxies within a project
+func (r *GCPReader) ListTargetHTTPSProxies(ctx context.Context, filter string) ([]compute.TargetHttpsProxy, error) {
+	service := compute.NewTargetHttpsProxiesService(r.compute)
+
+	resources := make([]compute.TargetHttpsProxy, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.TargetHttpsProxyList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute TargetHttpsProxy from google APIs")
+	}
+
+	return resources, nil
+
+}
+
+// ListURLMaps returns a list of URLMaps within a project
+func (r *GCPReader) ListURLMaps(ctx context.Context, filter string) ([]compute.UrlMap, error) {
+	service := compute.NewUrlMapsService(r.compute)
+
+	resources := make([]compute.UrlMap, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.UrlMapList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute UrlMap from google APIs")
 	}
 
 	return resources, nil

--- a/google/reader_generated.go
+++ b/google/reader_generated.go
@@ -34,6 +34,28 @@ func (r *GCPReader) ListBackendServices(ctx context.Context, filter string) ([]c
 
 }
 
+// ListBackendBuckets returns a list of BackendBuckets within a project
+func (r *GCPReader) ListBackendBuckets(ctx context.Context, filter string) ([]compute.BackendBucket, error) {
+	service := compute.NewBackendBucketsService(r.compute)
+
+	resources := make([]compute.BackendBucket, 0)
+
+	if err := service.List(r.project).
+		Filter(filter).
+		MaxResults(int64(r.maxResults)).
+		Pages(ctx, func(list *compute.BackendBucketList) error {
+			for _, res := range list.Items {
+				resources = append(resources, *res)
+			}
+			return nil
+		}); err != nil {
+		return nil, errors.Wrap(err, "unable to list compute BackendBucket from google APIs")
+	}
+
+	return resources, nil
+
+}
+
 // ListBuckets returns a list of Buckets within a project
 func (r *GCPReader) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
 	service := storage.NewBucketsService(r.storage)

--- a/google/resources.go
+++ b/google/resources.go
@@ -39,6 +39,7 @@ const (
 	DNSRecordSet
 	ProjectIAMCustomRole
 	StorageBucket
+	StorageBucketIAMPolicy
 	SQLDatabaseInstance
 )
 
@@ -64,6 +65,7 @@ var (
 		DNSRecordSet:                recordSetDNS,
 		ProjectIAMCustomRole:        projectIAMCustomRole,
 		StorageBucket:               storageBucket,
+		StorageBucketIAMPolicy:      storageBucketIAMPolicy,
 		SQLDatabaseInstance:         sqlDatabaseInstance,
 	}
 )
@@ -350,6 +352,21 @@ func projectIAMCustomRole(ctx context.Context, g *google, resourceType string, f
 	resources := make([]provider.Resource, 0, len(roles))
 	for _, role := range roles {
 		r := provider.NewResource(role.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+// storageBucketIAMPolicy will import the policies binded to a bucket. We need to iterate over the
+// bucket list
+func storageBucketIAMPolicy(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	buckets, err := g.gcpr.ListBuckets(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list bucket policies custom roles from reader")
+	}
+	resources := make([]provider.Resource, 0, len(buckets))
+	for _, bucket := range buckets {
+		r := provider.NewResource(bucket.Name, resourceType, g)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/google/resources.go
+++ b/google/resources.go
@@ -26,6 +26,7 @@ const (
 	// * frontend configuration: target_http(s)_proxy + global_forwarding_rule
 	ComputeHealthCheck
 	ComputeInstanceGroup
+	ComputeBackendBucket
 	ComputeBackendService
 	ComputeSSLCertificate
 	ComputeTargetHTTPProxy
@@ -50,6 +51,7 @@ var (
 		ComputeHealthCheck:          computeHealthCheck,
 		ComputeInstanceGroup:        computeInstanceGroup,
 		ComputeBackendService:       computeBackendService,
+		ComputeBackendBucket:        computeBackendBucket,
 		ComputeSSLCertificate:       computeSSLCertificate,
 		ComputeTargetHTTPProxy:      computeTargetHTTPProxy,
 		ComputeTargetHTTPSProxy:     computeTargetHTTPSProxy,
@@ -320,6 +322,20 @@ func recordSetDNS(ctx context.Context, g *google, resourceType string, filters *
 			r := provider.NewResource(fmt.Sprintf("%s/%s/%s", z, rrset.Name, rrset.Type), resourceType, g)
 			resources = append(resources, r)
 		}
+	}
+	return resources, nil
+}
+
+func computeBackendBucket(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	f := initializeFilter(filters)
+	backends, err := g.gcpr.ListBackendBuckets(ctx, f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list backend buckets from reader")
+	}
+	resources := make([]provider.Resource, 0, len(backends))
+	for _, backend := range backends {
+		r := provider.NewResource(backend.Name, resourceType, g)
+		resources = append(resources, r)
 	}
 	return resources, nil
 }

--- a/google/resources.go
+++ b/google/resources.go
@@ -37,6 +37,7 @@ const (
 	ComputeDisk
 	DNSManagedZone
 	DNSRecordSet
+	ProjectIAMCustomRole
 	StorageBucket
 	SQLDatabaseInstance
 )
@@ -61,6 +62,7 @@ var (
 		ComputeDisk:                 computeDisk,
 		DNSManagedZone:              managedZoneDNS,
 		DNSRecordSet:                recordSetDNS,
+		ProjectIAMCustomRole:        projectIAMCustomRole,
 		StorageBucket:               storageBucket,
 		SQLDatabaseInstance:         sqlDatabaseInstance,
 	}
@@ -335,6 +337,19 @@ func computeBackendBucket(ctx context.Context, g *google, resourceType string, f
 	resources := make([]provider.Resource, 0, len(backends))
 	for _, backend := range backends {
 		r := provider.NewResource(backend.Name, resourceType, g)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func projectIAMCustomRole(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	roles, err := g.gcpr.ListProjectIAMCustomRoles(ctx, fmt.Sprintf("projects/%s", g.gcpr.project))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list project IAM custom roles from reader")
+	}
+	resources := make([]provider.Resource, 0, len(roles))
+	for _, role := range roles {
+		r := provider.NewResource(role.Name, resourceType, g)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/google/resources.go
+++ b/google/resources.go
@@ -268,13 +268,13 @@ func computeDisk(ctx context.Context, g *google, resourceType string, filters *f
 }
 
 func storageBucket(ctx context.Context, g *google, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
-	rules, err := g.gcpr.ListBuckets(ctx)
+	buckets, err := g.gcpr.ListBuckets(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list global forwarding rules from reader")
 	}
 	resources := make([]provider.Resource, 0)
-	for _, rule := range rules {
-		r := provider.NewResource(rule.Name, resourceType, g)
+	for _, bucket := range buckets {
+		r := provider.NewResource(bucket.Name, resourceType, g)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_storage_bucket_iam_policygoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 153, 183, 213, 245, 278, 300, 337, 367, 386, 409, 430, 460, 481, 509}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 153, 183, 213, 245, 278, 300, 337, 367, 386, 409, 430, 460, 481, 513, 541}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_storage_bucket_iam_policygoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -58,8 +58,10 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[430:460]: 16,
 	_ResourceTypeName[460:481]:      17,
 	_ResourceTypeLowerName[460:481]: 17,
-	_ResourceTypeName[481:509]:      18,
-	_ResourceTypeLowerName[481:509]: 18,
+	_ResourceTypeName[481:513]:      18,
+	_ResourceTypeLowerName[481:513]: 18,
+	_ResourceTypeName[513:541]:      19,
+	_ResourceTypeLowerName[513:541]: 19,
 }
 
 var _ResourceTypeNames = []string{
@@ -81,7 +83,8 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[409:430],
 	_ResourceTypeName[430:460],
 	_ResourceTypeName[460:481],
-	_ResourceTypeName[481:509],
+	_ResourceTypeName[481:513],
+	_ResourceTypeName[513:541],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_storage_bucket_iam_policygoogle_sql_database_instance"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_instance_iam_policygoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_storage_bucket_iam_policygoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 153, 183, 213, 245, 278, 300, 337, 367, 386, 409, 430, 460, 481, 513, 541}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 158, 187, 217, 247, 279, 312, 334, 371, 401, 420, 443, 464, 494, 515, 547, 575}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_storage_bucket_iam_policygoogle_sql_database_instance"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_instance_iam_policygoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_storage_bucket_iam_policygoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -32,36 +32,38 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[68:95]:   3,
 	_ResourceTypeName[95:124]:       4,
 	_ResourceTypeLowerName[95:124]:  4,
-	_ResourceTypeName[124:153]:      5,
-	_ResourceTypeLowerName[124:153]: 5,
-	_ResourceTypeName[153:183]:      6,
-	_ResourceTypeLowerName[153:183]: 6,
-	_ResourceTypeName[183:213]:      7,
-	_ResourceTypeLowerName[183:213]: 7,
-	_ResourceTypeName[213:245]:      8,
-	_ResourceTypeLowerName[213:245]: 8,
-	_ResourceTypeName[245:278]:      9,
-	_ResourceTypeLowerName[245:278]: 9,
-	_ResourceTypeName[278:300]:      10,
-	_ResourceTypeLowerName[278:300]: 10,
-	_ResourceTypeName[300:337]:      11,
-	_ResourceTypeLowerName[300:337]: 11,
-	_ResourceTypeName[337:367]:      12,
-	_ResourceTypeLowerName[337:367]: 12,
-	_ResourceTypeName[367:386]:      13,
-	_ResourceTypeLowerName[367:386]: 13,
-	_ResourceTypeName[386:409]:      14,
-	_ResourceTypeLowerName[386:409]: 14,
-	_ResourceTypeName[409:430]:      15,
-	_ResourceTypeLowerName[409:430]: 15,
-	_ResourceTypeName[430:460]:      16,
-	_ResourceTypeLowerName[430:460]: 16,
-	_ResourceTypeName[460:481]:      17,
-	_ResourceTypeLowerName[460:481]: 17,
-	_ResourceTypeName[481:513]:      18,
-	_ResourceTypeLowerName[481:513]: 18,
-	_ResourceTypeName[513:541]:      19,
-	_ResourceTypeLowerName[513:541]: 19,
+	_ResourceTypeName[124:158]:      5,
+	_ResourceTypeLowerName[124:158]: 5,
+	_ResourceTypeName[158:187]:      6,
+	_ResourceTypeLowerName[158:187]: 6,
+	_ResourceTypeName[187:217]:      7,
+	_ResourceTypeLowerName[187:217]: 7,
+	_ResourceTypeName[217:247]:      8,
+	_ResourceTypeLowerName[217:247]: 8,
+	_ResourceTypeName[247:279]:      9,
+	_ResourceTypeLowerName[247:279]: 9,
+	_ResourceTypeName[279:312]:      10,
+	_ResourceTypeLowerName[279:312]: 10,
+	_ResourceTypeName[312:334]:      11,
+	_ResourceTypeLowerName[312:334]: 11,
+	_ResourceTypeName[334:371]:      12,
+	_ResourceTypeLowerName[334:371]: 12,
+	_ResourceTypeName[371:401]:      13,
+	_ResourceTypeLowerName[371:401]: 13,
+	_ResourceTypeName[401:420]:      14,
+	_ResourceTypeLowerName[401:420]: 14,
+	_ResourceTypeName[420:443]:      15,
+	_ResourceTypeLowerName[420:443]: 15,
+	_ResourceTypeName[443:464]:      16,
+	_ResourceTypeLowerName[443:464]: 16,
+	_ResourceTypeName[464:494]:      17,
+	_ResourceTypeLowerName[464:494]: 17,
+	_ResourceTypeName[494:515]:      18,
+	_ResourceTypeLowerName[494:515]: 18,
+	_ResourceTypeName[515:547]:      19,
+	_ResourceTypeLowerName[515:547]: 19,
+	_ResourceTypeName[547:575]:      20,
+	_ResourceTypeLowerName[547:575]: 20,
 }
 
 var _ResourceTypeNames = []string{
@@ -70,21 +72,22 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[46:68],
 	_ResourceTypeName[68:95],
 	_ResourceTypeName[95:124],
-	_ResourceTypeName[124:153],
-	_ResourceTypeName[153:183],
-	_ResourceTypeName[183:213],
-	_ResourceTypeName[213:245],
-	_ResourceTypeName[245:278],
-	_ResourceTypeName[278:300],
-	_ResourceTypeName[300:337],
-	_ResourceTypeName[337:367],
-	_ResourceTypeName[367:386],
-	_ResourceTypeName[386:409],
-	_ResourceTypeName[409:430],
-	_ResourceTypeName[430:460],
-	_ResourceTypeName[460:481],
-	_ResourceTypeName[481:513],
-	_ResourceTypeName[513:541],
+	_ResourceTypeName[124:158],
+	_ResourceTypeName[158:187],
+	_ResourceTypeName[187:217],
+	_ResourceTypeName[217:247],
+	_ResourceTypeName[247:279],
+	_ResourceTypeName[279:312],
+	_ResourceTypeName[312:334],
+	_ResourceTypeName[334:371],
+	_ResourceTypeName[371:401],
+	_ResourceTypeName[401:420],
+	_ResourceTypeName[420:443],
+	_ResourceTypeName[443:464],
+	_ResourceTypeName[464:494],
+	_ResourceTypeName[494:515],
+	_ResourceTypeName[515:547],
+	_ResourceTypeName[547:575],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 153, 183, 213, 245, 278, 300, 337, 367, 386, 409, 430, 451, 479}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 153, 183, 213, 245, 278, 300, 337, 367, 386, 409, 430, 460, 481, 509}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_project_iam_custom_rolegoogle_storage_bucketgoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -54,10 +54,12 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[386:409]: 14,
 	_ResourceTypeName[409:430]:      15,
 	_ResourceTypeLowerName[409:430]: 15,
-	_ResourceTypeName[430:451]:      16,
-	_ResourceTypeLowerName[430:451]: 16,
-	_ResourceTypeName[451:479]:      17,
-	_ResourceTypeLowerName[451:479]: 17,
+	_ResourceTypeName[430:460]:      16,
+	_ResourceTypeLowerName[430:460]: 16,
+	_ResourceTypeName[460:481]:      17,
+	_ResourceTypeLowerName[460:481]: 17,
+	_ResourceTypeName[481:509]:      18,
+	_ResourceTypeLowerName[481:509]: 18,
 }
 
 var _ResourceTypeNames = []string{
@@ -77,8 +79,9 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[367:386],
 	_ResourceTypeName[386:409],
 	_ResourceTypeName[409:430],
-	_ResourceTypeName[430:451],
-	_ResourceTypeName[451:479],
+	_ResourceTypeName[430:460],
+	_ResourceTypeName[460:481],
+	_ResourceTypeName[481:509],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/google/resourcetype_enumer.go
+++ b/google/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
 
-var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 154, 184, 216, 249, 271, 308, 338, 357, 380, 401, 422, 450}
+var _ResourceTypeIndex = [...]uint16{0, 23, 46, 68, 95, 124, 153, 183, 213, 245, 278, 300, 337, 367, 386, 409, 430, 451, 479}
 
-const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
+const _ResourceTypeLowerName = "google_compute_instancegoogle_compute_firewallgoogle_compute_networkgoogle_compute_health_checkgoogle_compute_instance_groupgoogle_compute_backend_bucketgoogle_compute_backend_servicegoogle_compute_ssl_certificategoogle_compute_target_http_proxygoogle_compute_target_https_proxygoogle_compute_url_mapgoogle_compute_global_forwarding_rulegoogle_compute_forwarding_rulegoogle_compute_diskgoogle_dns_managed_zonegoogle_dns_record_setgoogle_storage_bucketgoogle_sql_database_instance"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:23]:         0,
@@ -32,30 +32,32 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[68:95]:   3,
 	_ResourceTypeName[95:124]:       4,
 	_ResourceTypeLowerName[95:124]:  4,
-	_ResourceTypeName[124:154]:      5,
-	_ResourceTypeLowerName[124:154]: 5,
-	_ResourceTypeName[154:184]:      6,
-	_ResourceTypeLowerName[154:184]: 6,
-	_ResourceTypeName[184:216]:      7,
-	_ResourceTypeLowerName[184:216]: 7,
-	_ResourceTypeName[216:249]:      8,
-	_ResourceTypeLowerName[216:249]: 8,
-	_ResourceTypeName[249:271]:      9,
-	_ResourceTypeLowerName[249:271]: 9,
-	_ResourceTypeName[271:308]:      10,
-	_ResourceTypeLowerName[271:308]: 10,
-	_ResourceTypeName[308:338]:      11,
-	_ResourceTypeLowerName[308:338]: 11,
-	_ResourceTypeName[338:357]:      12,
-	_ResourceTypeLowerName[338:357]: 12,
-	_ResourceTypeName[357:380]:      13,
-	_ResourceTypeLowerName[357:380]: 13,
-	_ResourceTypeName[380:401]:      14,
-	_ResourceTypeLowerName[380:401]: 14,
-	_ResourceTypeName[401:422]:      15,
-	_ResourceTypeLowerName[401:422]: 15,
-	_ResourceTypeName[422:450]:      16,
-	_ResourceTypeLowerName[422:450]: 16,
+	_ResourceTypeName[124:153]:      5,
+	_ResourceTypeLowerName[124:153]: 5,
+	_ResourceTypeName[153:183]:      6,
+	_ResourceTypeLowerName[153:183]: 6,
+	_ResourceTypeName[183:213]:      7,
+	_ResourceTypeLowerName[183:213]: 7,
+	_ResourceTypeName[213:245]:      8,
+	_ResourceTypeLowerName[213:245]: 8,
+	_ResourceTypeName[245:278]:      9,
+	_ResourceTypeLowerName[245:278]: 9,
+	_ResourceTypeName[278:300]:      10,
+	_ResourceTypeLowerName[278:300]: 10,
+	_ResourceTypeName[300:337]:      11,
+	_ResourceTypeLowerName[300:337]: 11,
+	_ResourceTypeName[337:367]:      12,
+	_ResourceTypeLowerName[337:367]: 12,
+	_ResourceTypeName[367:386]:      13,
+	_ResourceTypeLowerName[367:386]: 13,
+	_ResourceTypeName[386:409]:      14,
+	_ResourceTypeLowerName[386:409]: 14,
+	_ResourceTypeName[409:430]:      15,
+	_ResourceTypeLowerName[409:430]: 15,
+	_ResourceTypeName[430:451]:      16,
+	_ResourceTypeLowerName[430:451]: 16,
+	_ResourceTypeName[451:479]:      17,
+	_ResourceTypeLowerName[451:479]: 17,
 }
 
 var _ResourceTypeNames = []string{
@@ -64,18 +66,19 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[46:68],
 	_ResourceTypeName[68:95],
 	_ResourceTypeName[95:124],
-	_ResourceTypeName[124:154],
-	_ResourceTypeName[154:184],
-	_ResourceTypeName[184:216],
-	_ResourceTypeName[216:249],
-	_ResourceTypeName[249:271],
-	_ResourceTypeName[271:308],
-	_ResourceTypeName[308:338],
-	_ResourceTypeName[338:357],
-	_ResourceTypeName[357:380],
-	_ResourceTypeName[380:401],
-	_ResourceTypeName[401:422],
-	_ResourceTypeName[422:450],
+	_ResourceTypeName[124:153],
+	_ResourceTypeName[153:183],
+	_ResourceTypeName[183:213],
+	_ResourceTypeName[213:245],
+	_ResourceTypeName[245:278],
+	_ResourceTypeName[278:300],
+	_ResourceTypeName[300:337],
+	_ResourceTypeName[337:367],
+	_ResourceTypeName[367:386],
+	_ResourceTypeName[386:409],
+	_ResourceTypeName[409:430],
+	_ResourceTypeName[430:451],
+	_ResourceTypeName[451:479],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
in this PR, we add the final CDN component ([compute backend bucket](https://www.terraform.io/docs/providers/google/r/compute_backend_bucket.html)).

IAM policies are started to be implemented. GCP handles IAM for each service:

- google_compute_iam_*
- google_storage_iam_*
- google_project_iam_*
- ...

About `ProjectCustomRole`, this one can't be generated since `Parent` needs to be set in the fluent API. If this type of request becomes redundant, we'll incorporate to the template. 

A cache needs also to be implemented since IAM import relies on the entities where IAM is applied. This cache would be embedded in the Function generation with a `IsCached` parameter to handle a seamless caching.