### PR TITLE
aws/resources: Befor importing 'aws_iam_user_group_membership' check grups names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - Provide filters to resource functions instead of tags only
   ([PR #92](https://github.com/cycloidio/terracognita/pull/92))
 
+## Fixed
+
+- Error when importing `aws_iam_user_group_membership` without groups
+  ([Issue #104](https://github.com/cycloidio/terracognita/issues/104))
+
 ## [0.4.0] _2020-03-31_
 
 ### Added

--- a/aws/resources.go
+++ b/aws/resources.go
@@ -1092,8 +1092,14 @@ func iamUserGroupMemberships(ctx context.Context, a *aws, resourceType string, f
 	if err != nil {
 		return nil, err
 	}
-
 	resources := make([]provider.Resource, 0)
+
+	// If the user has no Groups then we do not need to proceed
+	// or TF will return an error of malformed ID
+	if len(groupNames) == 0 {
+		return resources, nil
+	}
+
 	for _, un := range userNames {
 		// The format expected by TF is <user-name>/<group-name1>/...
 		r, err := initializeResource(a, strings.Join(append([]string{un}, groupNames...), "/"), resourceType)


### PR DESCRIPTION
If there is no groups we cannot import this resources so we should skip it

Closes #104 