### PR TITLE
aws/resources: Filter the Instances for 'stopped' and 'running'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - aws: `aws_lb`, `aws_lb_listener`, `aws_lb_listener_rule`, `aws_lb_target_group`
   ([PR #96](https://github.com/cycloidio/terracognita/pull/96))
 - aws: Pagination of all the functions on the reader
-  ([Issue #13](https://github.com/cycloidio/terracognita/issue/13))
+  ([Issue #13](https://github.com/cycloidio/terracognita/issues/13))
 
 ### Changed
 
@@ -14,6 +14,11 @@
   ([PR #96](https://github.com/cycloidio/terracognita/pull/96))
 - Provide filters to resource functions instead of tags only
   ([PR #92](https://github.com/cycloidio/terracognita/pull/92))
+
+## Fixed
+
+- Filtering `aws_instances` for `running` and `stopped` status so we don't fetch `terminated`
+  ([Issue #63](https://github.com/cycloidio/terracognita/issues/105))
 
 ## [0.4.0] _2020-03-31_
 

--- a/aws/resources.go
+++ b/aws/resources.go
@@ -195,8 +195,13 @@ func initializeResource(a *aws, ID, t string) (provider.Resource, error) {
 }
 
 func instances(ctx context.Context, a *aws, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	fl := toEC2Filters(filters)
+	fl = append(fl, &ec2.Filter{
+		Name:   awsSDK.String("instance-state-name"),
+		Values: []*string{awsSDK.String("running"), awsSDK.String("stopped")},
+	})
 	var input = &ec2.DescribeInstancesInput{
-		Filters: toEC2Filters(filters),
+		Filters: fl,
 	}
 
 	instances, err := a.awsr.GetInstances(ctx, input)


### PR DESCRIPTION
This are the only states that we care about

Close #105 