### PR TITLE
util/retry: Add the 'errors' we use internally as exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - aws: `aws_lb`, `aws_lb_listener`, `aws_lb_listener_rule`, `aws_lb_target_group`
   ([PR #96](https://github.com/cycloidio/terracognita/pull/96))
 - aws: Pagination of all the functions on the reader
-  ([Issue #13](https://github.com/cycloidio/terracognita/issue/13))
+  ([Issue #13](https://github.com/cycloidio/terracognita/issues/13))
 
 ### Changed
 
@@ -19,6 +19,8 @@
 
 - Error when importing `aws_iam_user_group_membership` without groups
   ([Issue #104](https://github.com/cycloidio/terracognita/issues/104))
+- util/retry now ignores the internal errors format
+  ([Issue #106](https://github.com/cycloidio/terracognita/issues/106))
 
 ## [0.4.0] _2020-03-31_
 

--- a/util/retry.go
+++ b/util/retry.go
@@ -30,11 +30,14 @@ func Retry(rfn RetryFn, times int, interval time.Duration) error {
 		// This is a fix because 'request.IsErrorRetryable(err)' will always
 		// retry normal errors "just in case" and we do not want to retry errors
 		// that we return
-		if fmt.Sprintf("%T", err) == "*errors.errorString" {
+		// *errors.errorString is the standar lib
+		// *errors.fundamental is the github.com/pkg/errors
+		// This way if it's an std error or one from us we skip the Retry
+		if fmt.Sprintf("%T", err) == "*errors.errorString" || fmt.Sprintf("%T", err) == "*errors.fundamental" {
 			return err
 		}
 		if request.IsErrorRetryable(err) || request.IsErrorThrottle(err) || request.IsErrorExpiredCreds(err) {
-			log.Get().Log("func", "utils.Retry", "msg", "waiting for Throttling error", "times-left", times)
+			log.Get().Log("func", "utils.Retry", "msg", "waiting for Throttling error", "err", fmt.Sprintf("%+v", err), "times-left", times)
 			time.Sleep(interval)
 			return Retry(rfn, times, interval)
 		}


### PR DESCRIPTION
This way the errors will be skipped and fault retries will be avoided.

This is still a hack but for the real implementation/solution we have to agree on https://github.com/cycloidio/terracognita/issues/93 so we can create an internal error type and directly assert to that type to skip errors that we know are do not need a Retry.

Close #106 close #105 