### PR TITLE
aws_iam_user_group_membership: do not write resource with empty group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- aws resources: do not write group_membership if the user has no groups.
+  ([issue #111](https://github.com/cycloidio/terracognita/issue/111))
 - filter: update IsExcluded and add IsIncluded to verify multiple resources.
   ([PR #96](https://github.com/cycloidio/terracognita/pull/96))
 - Provide filters to resource functions instead of tags only

--- a/aws/cmd/functions.go
+++ b/aws/cmd/functions.go
@@ -536,6 +536,18 @@ var (
 			`,
 		},
 		Function{
+			Entity:                "GroupsForUser",
+			Prefix:                "List",
+			Service:               "iam",
+			FnAttributeList:       "Groups",
+			SingularEntity:        "Group",
+			FnPaginationAttribute: "Marker",
+			Documentation: `
+			// GetGroupsForUser returns the IAM GroupsForUser on the given input
+			// Returned values are commented in the interface doc comment block.
+			`,
+		},
+		Function{
 			Entity:           "OpenIDConnectProviders",
 			Prefix:           "List",
 			Service:          "iam",

--- a/aws/reader/reader.go
+++ b/aws/reader/reader.go
@@ -229,6 +229,10 @@ type Reader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetInstanceProfiles(ctx context.Context, input *iam.ListInstanceProfilesInput) ([]*iam.InstanceProfile, error)
 
+	// GetGroupsForUser returns the IAM GroupsForUser on the given input
+	// Returned values are commented in the interface doc comment block.
+	GetGroupsForUser(ctx context.Context, input *iam.ListGroupsForUserInput) ([]*iam.Group, error)
+
 	// GetOpenIDConnectProviders returns the IAM OpenIDConnectProviders on the given input
 	// Returned values are commented in the interface doc comment block.
 	GetOpenIDConnectProviders(ctx context.Context, input *iam.ListOpenIDConnectProvidersInput) ([]*iam.OpenIDConnectProviderListEntry, error)
@@ -1492,6 +1496,33 @@ func (c *connector) GetInstanceProfiles(ctx context.Context, input *iam.ListInst
 		hasNextToken = o.Marker != nil
 
 		opt = append(opt, o.InstanceProfiles...)
+
+	}
+
+	return opt, nil
+}
+
+func (c *connector) GetGroupsForUser(ctx context.Context, input *iam.ListGroupsForUserInput) ([]*iam.Group, error) {
+	if c.svc.iam == nil {
+		c.svc.iam = iam.New(c.svc.session)
+	}
+
+	opt := make([]*iam.Group, 0)
+
+	hasNextToken := true
+	for hasNextToken {
+		o, err := c.svc.iam.ListGroupsForUserWithContext(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if input == nil {
+			input = &iam.ListGroupsForUserInput{}
+		}
+		input.Marker = o.Marker
+		hasNextToken = o.Marker != nil
+
+		opt = append(opt, o.Groups...)
 
 	}
 


### PR DESCRIPTION
If the user have no group, empty group_membership is written