### PR TITLE
chore: add github template issue feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_feature.md
+++ b/.github/ISSUE_TEMPLATE/new_feature.md
@@ -1,0 +1,18 @@
+---
+name: New Feature
+about: new feature proposal for Terracognita
+title: ''
+labels: "Feature"
+assignees: ''
+---
+### Abstract
+<!-- (Required) Only a few lines that should be understandable by everyone -->
+
+### Proposal
+<!-- (Required) What do you propose to add to Terracognita -->
+
+### Implementation
+<!-- (Optional) May be filled later after discussion with the maintainers -->
+
+### Open issues (if applicable)
+<!-- (Optional) If there are already opened issues on Terracognita repository linked to this issue -->


### PR DESCRIPTION
in order to prepare the public roadmap, we can submit this template to add a standard to the feature definition.

