### PR TITLE
Fix: Resource config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Error with the Resource name always being the alphanumeric instead of the Tag Name
+  ([PR #124](https://github.com/cycloidio/terracognita/issues/124))
+
 ## [0.5.0] _2020-06-19_
 
 ### Added
@@ -25,7 +30,7 @@
 - Upgraded all the Provider and Terraform versions
   ([PR #114](https://github.com/cycloidio/terracognita/pull/114))
 
-## Fixed
+### Fixed
 
 - Error when importing `aws_iam_user_group_membership` without groups
   ([Issue #104](https://github.com/cycloidio/terracognita/issues/104))
@@ -73,7 +78,7 @@
 - 'raws' lib to be an internal library instead of a dependency
   ([Issue #69](https://github.com/cycloidio/terracognita/issues/69))
 
-## Fixed
+### Fixed
 
 - '--region' flag working for different subcommands
   ([PR #63](https://github.com/cycloidio/terracognita/pull/63))

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -83,10 +83,10 @@ func (w *Writer) Has(key string) (bool, error) {
 	name := strings.Join(keys[1:], "")
 
 	if _, ok := w.Config["resource"].(map[string]map[string]interface{})[keys[0]][name]; ok {
-		return false, errors.Wrapf(errcode.ErrWriterAlreadyExistsKey, "with key %q", key)
+		return true, nil
 	}
 
-	return true, nil
+	return false, nil
 }
 
 // Sync writes the content of the Config to the

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -29,9 +29,10 @@ func TestHCLWriter_Write(t *testing.T) {
 			value = map[string]interface{}{
 				"key": "value",
 			}
+			key = "type.name"
 		)
 
-		err := hw.Write("type.name", value)
+		err := hw.Write(key, value)
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]interface{}{
@@ -43,6 +44,15 @@ func TestHCLWriter_Write(t *testing.T) {
 				},
 			},
 		}, hw.Config)
+		t.Run("Has", func(t *testing.T) {
+			ok, err := hw.Has(key)
+			require.NoError(t, err)
+			assert.True(t, ok)
+
+			ok, err = hw.Has("type.new")
+			require.NoError(t, err)
+			assert.False(t, ok)
+		})
 	})
 	t.Run("ErrRequiredKey", func(t *testing.T) {
 		var (

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -396,7 +396,7 @@ func (r *resource) State(w writer.Writer) error {
 		// and store it, so net time it'll use that one on any config
 		if r.configName == "" {
 			configName := tag.GetNameFromTag(r.provider.TagKey(), r.data, r.id)
-			if ok, err := w.Has(configName); err != nil {
+			if ok, err := w.Has(fmt.Sprintf("%s.%s", r.resourceType, configName)); err != nil {
 				return err
 			} else if ok {
 				configName = pwgen.Alpha(5)
@@ -428,8 +428,8 @@ func (r *resource) HCL(w writer.Writer) error {
 	// If it does not have any configName we will generate one
 	// and store it, so net time it'll use that one on any config
 	if r.configName == "" {
-		configName := fmt.Sprintf("%s.%s", r.resourceType, tag.GetNameFromTag(r.provider.TagKey(), r.data, r.id))
-		if ok, err := w.Has(configName); err != nil {
+		configName := tag.GetNameFromTag(r.provider.TagKey(), r.data, r.id)
+		if ok, err := w.Has(fmt.Sprintf("%s.%s", r.resourceType, configName)); err != nil {
 			return err
 		} else if ok {
 			configName = pwgen.Alpha(5)

--- a/state/writer_test.go
+++ b/state/writer_test.go
@@ -36,6 +36,7 @@ func TestWrite(t *testing.T) {
 			b    = &bytes.Buffer{}
 			sw   = state.NewWriter(b)
 			tp   = "aws_iam_user"
+			key  = "aws.name"
 		)
 		defer ctrl.Finish()
 
@@ -53,12 +54,21 @@ func TestWrite(t *testing.T) {
 
 		prv.EXPECT().String().Return("aws").AnyTimes()
 
-		err = sw.Write("aws.name", res)
+		err = sw.Write(key, res)
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]provider.Resource{
-			"aws.name": res,
+			key: res,
 		}, sw.Config)
+		t.Run("Has", func(t *testing.T) {
+			ok, err := sw.Has(key)
+			require.NoError(t, err)
+			assert.True(t, ok)
+
+			ok, err = sw.Has("aws.new")
+			require.NoError(t, err)
+			assert.False(t, ok)
+		})
 	})
 	t.Run("ErrRequiredKey", func(t *testing.T) {
 		sw := state.NewWriter(nil)


### PR DESCRIPTION
Fixed the logic to choose a Resource Name from the `provider.TagKey()`.`Name`. It was not working as expected and the resources where always having the random alphanumeric value instead of the other one.

Also added some more test on the part that where failing and did not have test.