### PR TITLE
hcl: avoid mutual interpolation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([PR #124](https://github.com/cycloidio/terracognita/pull/124))
 - Pagination and nil pointer errors
   ([PR #123](https://github.com/cycloidio/terracognita/pull/123))
+- Error with mutual interpolation between resources
+  ([PR #125](https://github.com/cycloidio/terracognita/pull/125))
 
 ## [0.5.0] _2020-06-19_
 


### PR DESCRIPTION
this kind of interpolation (between 2 resources) leads to cyclic references at TF runtime. To avoid it, we build a list of current relations between resources then we check if a relation is already present before adding a ref to another resource