### PR TITLE
cli: add option to deactivate interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - aws resource: `aws_alb_listener_certificate`, `aws_lb_cookie_stickiness_policy`, `aws_lb_target_group_attachment`, `aws_volume_attachment`, `aws_elasticsearch_domain`, `aws_elasticsearch_domain_policy`, `aws_lambda_function`, `aws_api_gateway_rest_api`, `aws_api_gateway_deployment`, `aws_api_gateway_stage`, `aws_api_gateway_resource`.
   ([PR #128](https://github.com/cycloidio/terracognita/pull/128))
+- cli option to deactivate interpolation
+  ([PR #133](https://github.com/cycloidio/terracognita/pull/133))
 
 ## [0.5.1] _2020-07-17_
 

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -68,15 +68,16 @@ var (
 			}
 
 			var hclW, stateW writer.Writer
+			options := &writer.Options{Interpolate: viper.GetBool("interpolate")}
 
 			if hclOut != nil {
 				logger.Log("msg", "initializing HCL writer")
-				hclW = hcl.NewWriter(hclOut)
+				hclW = hcl.NewWriter(hclOut, options)
 			}
 
 			if stateOut != nil {
 				logger.Log("msg", "initializing TFState writer")
-				stateW = state.NewWriter(stateOut)
+				stateW = state.NewWriter(stateOut, options)
 			}
 
 			logger.Log("msg", "importing")

--- a/cmd/azurerm.go
+++ b/cmd/azurerm.go
@@ -65,15 +65,16 @@ var (
 			}
 
 			var hclW, stateW writer.Writer
+			options := &writer.Options{Interpolate: viper.GetBool("interpolate")}
 
 			if hclOut != nil {
 				logger.Log("msg", "initializing HCL writer")
-				hclW = hcl.NewWriter(hclOut)
+				hclW = hcl.NewWriter(hclOut, options)
 			}
 
 			if stateOut != nil {
 				logger.Log("msg", "initializing TFState writer")
-				stateW = state.NewWriter(stateOut)
+				stateW = state.NewWriter(stateOut, options)
 			}
 
 			logger.Log("msg", "importing")

--- a/cmd/google.go
+++ b/cmd/google.go
@@ -73,15 +73,16 @@ var (
 			}
 
 			var hclW, stateW writer.Writer
+			options := &writer.Options{Interpolate: viper.GetBool("interpolate")}
 
 			if hclOut != nil {
 				logger.Log("msg", "initializing HCL writer")
-				hclW = hcl.NewWriter(hclOut)
+				hclW = hcl.NewWriter(hclOut, options)
 			}
 
 			if stateOut != nil {
 				logger.Log("msg", "initializing TFState writer")
-				stateW = state.NewWriter(stateOut)
+				stateW = state.NewWriter(stateOut, options)
 			}
 
 			logger.Log("msg", "importing")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,6 +114,9 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolP("debug", "d", false, "Activate the debug mode wich includes TF logs via TF_LOG=TRACE|DEBUG|INFO|WARN|ERROR configuration https://www.terraform.io/docs/internals/debugging.html")
 	_ = viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
+
+	RootCmd.PersistentFlags().BoolP("interpolate", "", true, "Activate the interpolation for the HCL and the dependencies building for the State file")
+	_ = viper.BindPFlag("interpolate", RootCmd.PersistentFlags().Lookup("interpolate"))
 }
 
 func initViper() {

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/log"
+	"github.com/cycloidio/terracognita/writer"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/fmtcmd"
 	"github.com/hashicorp/hcl/hcl/printer"
@@ -25,15 +26,17 @@ type Writer struct {
 	// TODO: Change it to "map[string]map[string]schema.ResourceData"
 	Config map[string]interface{}
 	writer io.Writer
+	opts   *writer.Options
 }
 
 // NewWriter rerturns an Writer initialization
-func NewWriter(w io.Writer) *Writer {
+func NewWriter(w io.Writer, opts *writer.Options) *Writer {
 	cfg := make(map[string]interface{})
 	cfg["resource"] = make(map[string]map[string]interface{})
 	return &Writer{
 		Config: cfg,
 		writer: w,
+		opts:   opts,
 	}
 }
 
@@ -129,6 +132,9 @@ func (w *Writer) Sync() error {
 // Interpolate replaces the hardcoded resources link
 // with TF interpolation
 func (w *Writer) Interpolate(i map[string]string) {
+	if !w.opts.Interpolate {
+		return
+	}
 	resources := w.Config["resource"]
 	// who's interpolated with who
 	relations := make(map[string]struct{}, 0)

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/hcl"
+	"github.com/cycloidio/terracognita/writer"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 
 func TestNewHCLWriter(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		hw := hcl.NewWriter(nil)
+		hw := hcl.NewWriter(nil, &writer.Options{Interpolate: true})
 
 		assert.Equal(t, map[string]interface{}{
 			"resource": make(map[string]map[string]interface{}),
@@ -26,7 +27,7 @@ func TestHCLWriter_Write(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			b     = &bytes.Buffer{}
-			hw    = hcl.NewWriter(b)
+			hw    = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 			value = map[string]interface{}{
 				"key": "value",
 			}
@@ -58,7 +59,7 @@ func TestHCLWriter_Write(t *testing.T) {
 	t.Run("ErrRequiredKey", func(t *testing.T) {
 		var (
 			b  = &bytes.Buffer{}
-			hw = hcl.NewWriter(b)
+			hw = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 		)
 
 		err := hw.Write("", nil)
@@ -67,7 +68,7 @@ func TestHCLWriter_Write(t *testing.T) {
 	t.Run("ErrRequiredValue", func(t *testing.T) {
 		var (
 			b  = &bytes.Buffer{}
-			hw = hcl.NewWriter(b)
+			hw = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 		)
 
 		err := hw.Write("type.name", nil)
@@ -76,7 +77,7 @@ func TestHCLWriter_Write(t *testing.T) {
 	t.Run("ErrInvalidKey", func(t *testing.T) {
 		var (
 			b  = &bytes.Buffer{}
-			hw = hcl.NewWriter(b)
+			hw = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 		)
 
 		err := hw.Write("type.name.name", "")
@@ -91,7 +92,7 @@ func TestHCLWriter_Write(t *testing.T) {
 	t.Run("ErrAlreadyExistsKey", func(t *testing.T) {
 		var (
 			b  = &bytes.Buffer{}
-			hw = hcl.NewWriter(b)
+			hw = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 		)
 
 		err := hw.Write("type.name", "")
@@ -106,7 +107,7 @@ func TestHCLWriter_Sync(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			b     = &bytes.Buffer{}
-			hw    = hcl.NewWriter(b)
+			hw    = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 			value = map[string]interface{}{
 				"key": "value",
 			}
@@ -130,7 +131,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			b     = &bytes.Buffer{}
-			hw    = hcl.NewWriter(b)
+			hw    = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 			value = map[string]interface{}{
 				"network": "to-be-interpolated",
 			}
@@ -159,7 +160,7 @@ resource "type" "name" {
 	t.Run("SuccessAvoidInterpolaception", func(t *testing.T) {
 		var (
 			b     = &bytes.Buffer{}
-			hw    = hcl.NewWriter(b)
+			hw    = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 			value = map[string]interface{}{
 				"network": "to-be-interpolated",
 			}
@@ -190,7 +191,7 @@ resource "type" "name" {
 	t.Run("SuccessMutualInterpolation", func(t *testing.T) {
 		var (
 			b        = &bytes.Buffer{}
-			hw       = hcl.NewWriter(b)
+			hw       = hcl.NewWriter(b, &writer.Options{Interpolate: true})
 			instance = map[string]interface{}{
 				"subnet_id": "1234",
 			}

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -213,4 +213,35 @@ resource "type" "name" {
 		// only one interpolation
 		assert.Equal(t, 1, strings.Count(b.String(), "$"))
 	})
+	t.Run("SuccessNoInterpolation", func(t *testing.T) {
+		var (
+			b     = &bytes.Buffer{}
+			hw    = hcl.NewWriter(b, &writer.Options{Interpolate: false})
+			value = map[string]interface{}{
+				"network": "should-not-be-interpolated",
+			}
+			network = map[string]interface{}{
+				"id":   "interpolated",
+				"name": "to-be-interpolated",
+			}
+			i   = make(map[string]string)
+			hcl = `resource "aType" "aName" {
+  id   = "interpolated"
+  name = "to-be-interpolated"
+}
+
+resource "type" "name" {
+  network = "should-not-be-interpolated"
+}
+`
+		)
+		i["should-not-be-interpolated"] = "${aType.aName.id}"
+		hw.Write("type.name", value)
+		hw.Write("aType.aName", network)
+
+		hw.Interpolate(i)
+		hw.Sync()
+
+		assert.Equal(t, hcl, b.String())
+	})
 }

--- a/mock/writer.go
+++ b/mock/writer.go
@@ -7,6 +7,7 @@ package mock
 import (
 	reflect "reflect"
 
+	writer "github.com/cycloidio/terracognita/writer"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -31,6 +32,20 @@ func NewWriter(ctrl *gomock.Controller) *Writer {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *Writer) EXPECT() *WriterMockRecorder {
 	return m.recorder
+}
+
+// GetOptions mocks base method
+func (m *Writer) GetOptions() *writer.Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOptions")
+	ret0, _ := ret[0].(*writer.Options)
+	return ret0
+}
+
+// GetOptions indicates an expected call of GetOptions
+func (mr *WriterMockRecorder) GetOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*Writer)(nil).GetOptions))
 }
 
 // Has mocks base method

--- a/state/writer.go
+++ b/state/writer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/log"
 	"github.com/cycloidio/terracognita/provider"
+	"github.com/cycloidio/terracognita/writer"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
@@ -20,14 +21,16 @@ type Writer struct {
 	Config map[string]provider.Resource
 	writer io.Writer
 	state  *states.SyncState
+	opts   *writer.Options
 }
 
 // NewWriter returns a TFStateWriter initialization
-func NewWriter(w io.Writer) *Writer {
+func NewWriter(w io.Writer, opts *writer.Options) *Writer {
 	return &Writer{
 		Config: make(map[string]provider.Resource),
 		writer: w,
 		state:  states.NewState().SyncWrapper(),
+		opts:   opts,
 	}
 }
 
@@ -113,4 +116,8 @@ func (w *Writer) Sync() error {
 }
 
 // Interpolate does nothing in `state` context
-func (w *Writer) Interpolate(i map[string]string) {}
+func (w *Writer) Interpolate(i map[string]string) {
+	if !w.opts.Interpolate {
+		return
+	}
+}

--- a/state/writer_test.go
+++ b/state/writer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cycloidio/terracognita/mock"
 	"github.com/cycloidio/terracognita/provider"
 	"github.com/cycloidio/terracognita/state"
+	"github.com/cycloidio/terracognita/writer"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform/configs/hcl2shim"
@@ -21,7 +22,7 @@ import (
 
 func TestNewWriter(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		sw := state.NewWriter(nil)
+		sw := state.NewWriter(nil, nil)
 
 		assert.Equal(t, make(map[string]provider.Resource), sw.Config)
 	})
@@ -34,7 +35,7 @@ func TestWrite(t *testing.T) {
 			prv  = mock.NewProvider(ctrl)
 			res  = mock.NewResource(ctrl)
 			b    = &bytes.Buffer{}
-			sw   = state.NewWriter(b)
+			sw   = state.NewWriter(b, &writer.Options{Interpolate: true})
 			tp   = "aws_iam_user"
 			key  = "aws.name"
 		)
@@ -71,13 +72,13 @@ func TestWrite(t *testing.T) {
 		})
 	})
 	t.Run("ErrRequiredKey", func(t *testing.T) {
-		sw := state.NewWriter(nil)
+		sw := state.NewWriter(nil, &writer.Options{Interpolate: true})
 
 		err := sw.Write("", nil)
 		assert.Equal(t, errcode.ErrWriterRequiredKey, errors.Cause(err))
 	})
 	t.Run("ErrRequiredValue", func(t *testing.T) {
-		sw := state.NewWriter(nil)
+		sw := state.NewWriter(nil, &writer.Options{Interpolate: true})
 
 		err := sw.Write("aws.key", nil)
 		assert.Equal(t, errcode.ErrWriterRequiredValue, errors.Cause(err))
@@ -88,7 +89,7 @@ func TestWrite(t *testing.T) {
 			prv  = mock.NewProvider(ctrl)
 			res  = mock.NewResource(ctrl)
 			b    = &bytes.Buffer{}
-			sw   = state.NewWriter(b)
+			sw   = state.NewWriter(b, &writer.Options{Interpolate: true})
 			tp   = "aws_iam_user"
 		)
 		defer ctrl.Finish()
@@ -114,7 +115,7 @@ func TestWrite(t *testing.T) {
 		assert.Equal(t, errcode.ErrWriterAlreadyExistsKey, errors.Cause(err))
 	})
 	t.Run("ErrInvalidTypeValue", func(t *testing.T) {
-		sw := state.NewWriter(nil)
+		sw := state.NewWriter(nil, &writer.Options{Interpolate: true})
 
 		err := sw.Write("aws.key", 0)
 		assert.Equal(t, errcode.ErrWriterInvalidTypeValue, errors.Cause(err))
@@ -125,7 +126,7 @@ func TestWrite(t *testing.T) {
 			res  = mock.NewResource(ctrl)
 		)
 		defer ctrl.Finish()
-		sw := state.NewWriter(nil)
+		sw := state.NewWriter(nil, &writer.Options{Interpolate: true})
 
 		err := sw.Write("key", res)
 		assert.Equal(t, errcode.ErrWriterInvalidKey, errors.Cause(err))
@@ -140,7 +141,7 @@ func TestSync(t *testing.T) {
 		var (
 			ctrl  = gomock.NewController(t)
 			b     = &bytes.Buffer{}
-			sw    = state.NewWriter(b)
+			sw    = state.NewWriter(b, &writer.Options{Interpolate: true})
 			prv   = mock.NewProvider(ctrl)
 			res   = mock.NewResource(ctrl)
 			tp    = "aws_iam_user"

--- a/writer/options.go
+++ b/writer/options.go
@@ -1,0 +1,9 @@
+package writer
+
+// Options given to the writers
+type Options struct {
+	// Interpolate means the ability to interpolate
+	// variables in HCL files or building dependencies
+	// in a TFState
+	Interpolate bool
+}


### PR DESCRIPTION
```
--interpolate       Activate the interpolation for the HCL and the dependencies building for the State file (default true)
```

This option allows the user to explicitly deactivate the built-in interpolation:

- deactivate the HCL interpolation (with `${...}`)
- deactivate the State interpolation (`dependencies` #131 )