### PR TITLE
hcl/writer: upgrade HCL lib to the HCL2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - cli option to deactivate interpolation
   ([PR #133](https://github.com/cycloidio/terracognita/pull/133))
 
+### Changed
+
+- HCL lib version from V1 to V2 and all the implications
+  ([PR #135](https://github.com/cycloidio/terracognita/pull/135))
+
 ## [0.5.1] _2020-07-17_
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cycloidio/terracognita
 require (
 	github.com/Azure/azure-sdk-for-go v42.1.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.10.0
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.31.9
 	github.com/chr4/pwgen v1.1.0
 	github.com/cycloidio/tfdocs v0.0.0-20200111145532-e6a80a93d7cc
@@ -10,6 +11,7 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/hashicorp/go-azure-helpers v0.10.0
 	github.com/hashicorp/hcl v1.0.0
+	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
 	github.com/hashicorp/terraform v0.12.26
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
@@ -24,7 +26,8 @@ require (
 	github.com/terraform-providers/terraform-provider-azurerm v1.44.1-0.20200605204846-1b0da11661ac
 	github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200605200304-d3a169b0353a
 	github.com/terraform-providers/terraform-provider-random v2.0.0+incompatible // indirect
-	github.com/zclconf/go-cty v1.4.2
+	github.com/zclconf/go-cty v1.5.1
+	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200515220128-d3bf790afa53 // indirect
 	google.golang.org/api v0.25.0
 )

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/golang/mock v1.4.3
 	github.com/hashicorp/go-azure-helpers v0.10.0
-	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/hcl/v2 v2.6.0
+	github.com/hashicorp/hcl/v2 v2.6.0 // indirect
+	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
 	github.com/hashicorp/terraform v0.12.26
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tj
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agl/ed25519 v0.0.0-20150830182803-278e1ec8e8a6 h1:LoeFxdq5zUCBQPhbQKE6zvoGwHMxCBlqwbH9+9kHoHA=
 github.com/agl/ed25519 v0.0.0-20150830182803-278e1ec8e8a6/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
@@ -467,6 +469,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
+github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
+github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6 h1:JImQpEeUQ+0DPFMaWzLA0GdUNPaUlCXLpfiqkSZBUfc=
 github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
@@ -892,8 +896,8 @@ github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.4.2 h1:GKcsRGjxZnRRlyVk2Y6PyG3fdcn3Pv0D7KT4xyYTLlE=
-github.com/zclconf/go-cty v1.4.2/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
+github.com/zclconf/go-cty v1.5.1 h1:oALUZX+aJeEBUe2a1+uD2+UTaYfEjnKFDEMRydkGvWE=
+github.com/zclconf/go-cty v1.5.1/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1065,6 +1069,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=

--- a/hcl/format.go
+++ b/hcl/format.go
@@ -16,6 +16,15 @@ var (
 		replaceFn func([]byte) []byte
 	}{
 		{
+			// Replace all the `"key" = "$${a.b.c}` for `"key" = a.b.c`
+			// the double `$` is setted by the hclwriter
+			// `$${a.b.c}` is the representation of HCL V1 interpolation passed
+			// trough hcl2/hclwrite. We need to change it to `a.b.c` to be HCL2
+			// compliant interpolation side.
+			match:   regexp.MustCompile(`"\$\${(.+)\.(.+)\.(.+)}"`),
+			replace: []byte(`$1.$2.$3`),
+		},
+		{
 			// Replace all the `"key" = "value"` for `key = "value"` except
 			// if it has a `.` on the key
 			match:   regexp.MustCompile(`"([^\d][\w\-_=]+)"\s=`),

--- a/hcl/format_test.go
+++ b/hcl/format_test.go
@@ -128,6 +128,19 @@ func TestFormat(t *testing.T) {
 				role = value
 			}`),
 		},
+		{
+			name: "ReplaceInterpolation11To12Format",
+			in: []byte(`
+			"resource" "aws_instance" "name" {
+				"env" = "value and ${this.must.stay}"
+				"role" = "$${this.is.a-role}"
+			}`),
+			out: []byte(`
+			resource "aws_instance" "name" {
+				env = "value and ${this.must.stay}"
+				role = this.is.a-role
+			}`),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In this PR, we upgrade the HCL lib to the its V2.

As expected (or not), the two libs are totally different. I first tried to take an approach "case by case" by using `reflect` on each values of the JSON config but it quickly becomes difficult / unmaintainable and you can miss some cases.

After looking around the `go-cty` lib, I found that you can extract the `cty.Type` from a raw JSON since `go-cty` relies actually on JSON. Once you have the `cty.Type`, you can easily found out the `cty.Value` and write your HCL blocks.

One thing, for the ingress/egress I found is that JSON side, we have a list:
```json
"ingress": [
    {"description": "...", "from_port": 123},
    {"description": "...", "from_port": 456},
]
```
so HCL side, we will ending with:

```hcl
  egress      = [{ cidr_blocks = ["0.0.0.0/0"], from_port = 0, protocol = "-1", to_port = 0 }]
```

which is good from a HCL PoV but wrong from a TF PoV. We need to have something like:
```hcl
  egress {
    cidr_blocks = ["0.0.0.0/0"]
    from_port   = 0
    protocol    = "-1"
    to_port     = 0
  }

  egress {
    cidr_blocks = ["0.0.0.0/0"]
    from_port   = 80
    protocol    = "tcp"
    to_port     = 80
  }
```

This is solved by this instructions: https://github.com/cycloidio/terracognita/pull/135/files#diff-b4c9306bf17ce7db3842f45d065fc511R128

Closes: #82 