### PR TITLE
provider/import: continue the import if we hit a custom error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - HCL lib version from V1 to V2 and all the implications
   ([PR #135](https://github.com/cycloidio/terracognita/pull/135))
 
+### Fixed
+
+- Crashing import by adding an error handling on provider errors
+  ([issue #138](https://github.com/cycloidio/terracognita/issues/138))
+
 ## [0.5.1] _2020-07-17_
 
 ### Fixed

--- a/errcode/codes.go
+++ b/errcode/codes.go
@@ -19,4 +19,8 @@ var (
 	ErrWriterAlreadyExistsKey = errors.New("the key already exists")
 
 	ErrFilterTargetsInvalid = errors.New("the filter targets has an invalid format")
+
+	// ErrProviderAPI will be raised when an error occurs provider side while
+	// using its APIs (authorization error, unavailable operation, ...)
+	ErrProviderAPI = errors.New("error while requesting the provider APIs")
 )

--- a/provider/import.go
+++ b/provider/import.go
@@ -90,7 +90,13 @@ func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filt
 		} else {
 			resources, err = p.Resources(ctx, t, f)
 			if err != nil {
-				return errors.WithStack(err)
+				// we filter the error: if it's an error provider side, we continue
+				// the import but we print the error.
+				if errors.Is(err, errcode.ErrProviderAPI) {
+					fmt.Fprintf(out, "\nunable to import resource %s: %s\n", t, err.Error())
+				} else {
+					return errors.WithStack(err)
+				}
 			}
 		}
 


### PR DESCRIPTION
if we hit an error in the importing step and the error is not a fundamental one, we print it and we continue the import. 


```shell
$ ./terracognita aws --access-key=$AWS_ACCESS_KEY --secret-key=$AWS_SECRET_KEY -i aws_ses_active_receipt_rule_set --hcl resources.tf --tfstate resources.tfstate --region eu-west-1
Starting Terracognita with version v0.5.1-23-gb27dfef
Importing with filters:
        Tags:    [],
        Include: [aws_ses_active_receipt_rule_set],
        Exclude: [],
        Targets: [],
Importing aws_ses_active_receipt_rule_set [1/1] Done!
Writing HCL Done!
Writing TFState Done!

$ ./terracognita aws --access-key=$AWS_ACCESS_KEY --secret-key=$AWS_SECRET_KEY -i aws_ses_active_receipt_rule_set --hcl resources.tf --tfstate resources.tfstate --region eu-west-2
Starting Terracognita with version v0.5.1-23-gb27dfef
Importing with filters:
        Tags:    [],
        Include: [aws_ses_active_receipt_rule_set],
        Exclude: [],
        Targets: [],

unable to import resource aws_ses_active_receipt_rule_set: error while reading from resource "aws_ses_active_receipt_rule_set": InvalidAction: Unavailable Operation
        status code: 400, request id: <request-id>
Writing HCL Done!
Writing TFState Done!
```

Closes: #138 