### PR TITLE
ci: add checkout params on pull-request resource

### DIFF
--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -187,6 +187,8 @@ jobs:
           path: pull-request
           status: pending
           target_url: 'https://console.cycloid.io/organizations/((customer))/projects/((project))/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_ID'
+        get_params:
+          integration_tool: checkout
 
       - task: unit-tests
         privileged: true


### PR DESCRIPTION
default behavior is to merge, which is not the desired one. It's already on the `get` but the `put` is executed right before the test so it's the one who matter.  