### PR TITLE
azurerm: add virtual desktops resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([PR #133](https://github.com/cycloidio/terracognita/pull/133))
 - AWS support for profile/config
   ([Issue #48](https://github.com/cycloidio/terracognita/issues/48))
+- Azure Virtual Desktop resources
+  ([PR #145](https://github.com/cycloidio/terracognita/pull/145))
 
 ### Changed
 

--- a/azurerm/cache.go
+++ b/azurerm/cache.go
@@ -43,3 +43,73 @@ func getVirtualNetworkNames(ctx context.Context, a *azurerm, rt string, filters 
 
 	return names, nil
 }
+
+func cacheVirtualMachines(ctx context.Context, a *azurerm, rt string, filters *filter.Filter) ([]provider.Resource, error) {
+	rs, err := a.cache.Get(rt)
+	if err != nil {
+		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
+			return nil, errors.WithStack(err)
+		}
+
+		rs, err = virtualMachines(ctx, a, rt, filters)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get virtual machines")
+		}
+
+		err = a.cache.Set(rt, rs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rs, nil
+}
+
+func getVirtualMachineNames(ctx context.Context, a *azurerm, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheVirtualMachines(ctx, a, rt, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(rs))
+	for _, i := range rs {
+		names = append(names, i.Data().Get("name").(string))
+	}
+
+	return names, nil
+}
+
+func cacheWorkflows(ctx context.Context, a *azurerm, rt string, filters *filter.Filter) ([]provider.Resource, error) {
+	rs, err := a.cache.Get(rt)
+	if err != nil {
+		if errors.Cause(err) != errcode.ErrCacheKeyNotFound {
+			return nil, errors.WithStack(err)
+		}
+
+		rs, err = logicAppWorkflows(ctx, a, rt, filters)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get workflows")
+		}
+
+		err = a.cache.Set(rt, rs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rs, nil
+}
+
+func getWorkflowNames(ctx context.Context, a *azurerm, rt string, filters *filter.Filter) ([]string, error) {
+	rs, err := cacheWorkflows(ctx, a, rt, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(rs))
+	for _, i := range rs {
+		names = append(names, i.Data().Get("name").(string))
+	}
+
+	return names, nil
+}

--- a/azurerm/cmd/generate.go
+++ b/azurerm/cmd/generate.go
@@ -59,6 +59,38 @@ var functions = []Function{
 			Type: "string",
 		},
 	}},
+	Function{Resource: "WorkflowRun", API: "logic", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "workflowName",
+			Type: "string",
+		},
+		Arg{
+			Name: "top",
+			Type: "*int32",
+		},
+		Arg{
+			Name: "filter",
+			Type: "string",
+		},
+	}},
+	Function{Resource: "WorkflowRunAction", API: "logic", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "workflowName",
+			Type: "string",
+		},
+		Arg{
+			Name: "runName",
+			Type: "string",
+		},
+		Arg{
+			Name: "top",
+			Type: "*int32",
+		},
+		Arg{
+			Name: "filter",
+			Type: "string",
+		},
+	}},
 }
 
 func main() {

--- a/azurerm/cmd/generate.go
+++ b/azurerm/cmd/generate.go
@@ -18,12 +18,22 @@ var azureAPIs = []AzureAPI{
 var functions = []Function{
 	Function{Resource: "VirtualMachine", API: "compute", ResourceGroup: true},
 	Function{Resource: "VirtualNetwork", API: "network", ResourceGroup: true},
-	Function{Resource: "Subnet", API: "network", ResourceGroup: true, ExtraArgs: []string{"virtualNetworkName"}},
+	Function{Resource: "Subnet", API: "network", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "virtualNetworkName",
+			Type: "string",
+		},
+	}},
 	Function{Resource: "Interface", API: "network", ResourceGroup: true},
 	Function{Resource: "SecurityGroup", API: "network", ResourceGroup: true},
 	Function{Resource: "VirtualMachineScaleSet", API: "compute", ResourceGroup: true},
 	Function{Resource: "HostPool", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true},
-	Function{Resource: "ApplicationGroup", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true, ExtraArgs: []string{"filter"}},
+	Function{Resource: "ApplicationGroup", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "filter",
+			Type: "string",
+		},
+	}},
 }
 
 func main() {

--- a/azurerm/cmd/generate.go
+++ b/azurerm/cmd/generate.go
@@ -12,6 +12,7 @@ import (
 var azureAPIs = []AzureAPI{
 	AzureAPI{API: "compute", APIVersion: "2019-07-01"},
 	AzureAPI{API: "network", APIVersion: "2019-06-01"},
+	AzureAPI{API: "desktopvirtualization", APIVersion: "2019-12-10", IsPreview: true},
 }
 
 var functions = []Function{
@@ -21,6 +22,7 @@ var functions = []Function{
 	Function{Resource: "Interface", API: "network", ResourceGroup: true},
 	Function{Resource: "SecurityGroup", API: "network", ResourceGroup: true},
 	Function{Resource: "VirtualMachineScaleSet", API: "compute", ResourceGroup: true},
+	Function{Resource: "HostPool", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true},
 }
 
 func main() {

--- a/azurerm/cmd/generate.go
+++ b/azurerm/cmd/generate.go
@@ -13,6 +13,7 @@ var azureAPIs = []AzureAPI{
 	AzureAPI{API: "compute", APIVersion: "2019-07-01"},
 	AzureAPI{API: "network", APIVersion: "2019-06-01"},
 	AzureAPI{API: "desktopvirtualization", APIVersion: "2019-12-10", IsPreview: true},
+	AzureAPI{API: "logic", APIVersion: "2019-05-01"},
 }
 
 var functions = []Function{
@@ -29,6 +30,16 @@ var functions = []Function{
 	Function{Resource: "VirtualMachineScaleSet", API: "compute", ResourceGroup: true},
 	Function{Resource: "HostPool", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true},
 	Function{Resource: "ApplicationGroup", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "filter",
+			Type: "string",
+		},
+	}},
+	Function{Resource: "Workflow", ListFunction: "ListByResourceGroup", API: "logic", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "top",
+			Type: "*int32",
+		},
 		Arg{
 			Name: "filter",
 			Type: "string",

--- a/azurerm/cmd/generate.go
+++ b/azurerm/cmd/generate.go
@@ -45,6 +45,20 @@ var functions = []Function{
 			Type: "string",
 		},
 	}},
+	Function{Resource: "WorkflowTrigger", API: "logic", ResourceGroup: true, ExtraArgs: []Arg{
+		Arg{
+			Name: "workflowName",
+			Type: "string",
+		},
+		Arg{
+			Name: "top",
+			Type: "*int32",
+		},
+		Arg{
+			Name: "filter",
+			Type: "string",
+		},
+	}},
 }
 
 func main() {

--- a/azurerm/cmd/generate.go
+++ b/azurerm/cmd/generate.go
@@ -23,6 +23,7 @@ var functions = []Function{
 	Function{Resource: "SecurityGroup", API: "network", ResourceGroup: true},
 	Function{Resource: "VirtualMachineScaleSet", API: "compute", ResourceGroup: true},
 	Function{Resource: "HostPool", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true},
+	Function{Resource: "ApplicationGroup", ListFunction: "ListByResourceGroup", API: "desktopvirtualization", ResourceGroup: true, ExtraArgs: []string{"filter"}},
 }
 
 func main() {

--- a/azurerm/cmd/template.go
+++ b/azurerm/cmd/template.go
@@ -18,7 +18,7 @@ const (
 		"github.com/pkg/errors"
 
 		{{ range .AzureAPIs -}}
-		"github.com/Azure/azure-sdk-for-go/services/{{ .API }}/mgmt/{{ .APIVersion }}/{{ .API }}"
+		"github.com/Azure/azure-sdk-for-go/services/{{ if .IsPreview }}preview/{{ end }}{{ .API }}/mgmt/{{ .APIVersion }}{{ if .IsPreview }}-preview{{ end }}/{{ .API }}"
 		{{ end }}
 	)
 	`
@@ -81,6 +81,11 @@ type AzureAPI struct {
 	// Azure API Version to use
 	// ex: 2019-07-01
 	APIVersion string
+
+	// IsPreview defines if the API is a preview
+	// functionality
+	// https://docs.microsoft.com/en-us/azure/search/search-api-preview
+	IsPreview bool
 }
 
 // Function is the definition of one of the functions

--- a/azurerm/cmd/template.go
+++ b/azurerm/cmd/template.go
@@ -26,11 +26,11 @@ const (
 	// functionTmpl it's the implementation of a reader function
 	functionTmpl = `
 	// List{{ .Name }} returns a list of {{ .Name }} within a subscription {{ if .Location }}and a location {{ end }}{{ if .ResourceGroup }}and a resource group {{ end }}
-	func (ar *AzureReader) List{{ .Name }}(ctx context.Context{{ range .ExtraArgs }},{{ . }} string{{ end }}) ([]{{ .API }}.{{ .Resource }}, error) {
+	func (ar *AzureReader) List{{ .Name }}(ctx context.Context{{ range .ExtraArgs }},{{ .Name }} {{ .Type }} {{ end }}) ([]{{ .API }}.{{ .Resource }}, error) {
 		client := {{ .API }}.New{{ .Resource }}sClient(ar.config.SubscriptionID)
 		client.Authorizer = ar.authorizer
 
-		output, err := client.{{ .ListFunction }}(ctx{{ if .Location }}, ar.GetLocation(){{ end }}{{ if .ResourceGroup }}, ar.GetResourceGroupName(){{ end }}{{ range .ExtraArgs }},{{ . }}{{ end }})
+		output, err := client.{{ .ListFunction }}(ctx{{ if .Location }}, ar.GetLocation(){{ end }}{{ if .ResourceGroup }}, ar.GetResourceGroupName(){{ end }}{{ range .ExtraArgs }},{{ .Name }}{{ end }})
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to list {{ .API }}.{{ .Resource }} from Azure APIs")
 		}
@@ -68,6 +68,16 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// Arg can be used to define
+// extra args to pass to the generated
+// functions
+type Arg struct {
+	// Name of the arg
+	Name string
+	// Type of the arg
+	Type string
 }
 
 // AzureAPI is the definition of one of the Azure APIs
@@ -118,7 +128,7 @@ type Function struct {
 	Iterator bool
 
 	// ExtraArgs should be specified if extra arguments are required for the list function
-	ExtraArgs []string
+	ExtraArgs []Arg
 }
 
 // Execute uses the fnTmpl to interpolate f

--- a/azurerm/list_virtual_machine_extensions.go
+++ b/azurerm/list_virtual_machine_extensions.go
@@ -1,0 +1,24 @@
+package azurerm
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+)
+
+// ListVirtualMachineExtensions returns a list of VirtualMachineExtensions within a subscription and a resource group
+// it needs to be manually written since it does not follow the same pattern as the other resources. This "List" method
+// does not return a "...ListResultPage", but directly a slice holding the values
+func (ar *AzureReader) ListVirtualMachineExtensions(ctx context.Context, VMName string, expand string) ([]compute.VirtualMachineExtension, error) {
+	client := compute.NewVirtualMachineExtensionsClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.List(ctx, ar.GetResourceGroupName(), VMName, expand)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list compute.VirtualMachineExtension from Azure APIs")
+	}
+
+	return *output.Value, nil
+}

--- a/azurerm/reader_generated.go
+++ b/azurerm/reader_generated.go
@@ -7,7 +7,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2019-05-01/logic"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/preview/desktopvirtualization/mgmt/2019-12-10-preview/desktopvirtualization"
 )
 
 // ListVirtualMachines returns a list of VirtualMachines within a subscription and a resource group
@@ -135,6 +137,144 @@ func (ar *AzureReader) ListVirtualMachineScaleSets(ctx context.Context) ([]compu
 		return nil, errors.Wrap(err, "unable to list compute.VirtualMachineScaleSet from Azure APIs")
 	}
 	resources := make([]compute.VirtualMachineScaleSet, 0)
+	for output.NotDone() {
+
+		for _, res := range output.Values() {
+			resources = append(resources, res)
+		}
+
+		if err := output.NextWithContext(ctx); err != nil {
+			break
+		}
+	}
+	return resources, nil
+}
+
+// ListHostPools returns a list of HostPools within a subscription and a resource group
+func (ar *AzureReader) ListHostPools(ctx context.Context) ([]desktopvirtualization.HostPool, error) {
+	client := desktopvirtualization.NewHostPoolsClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.ListByResourceGroup(ctx, ar.GetResourceGroupName())
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list desktopvirtualization.HostPool from Azure APIs")
+	}
+	resources := make([]desktopvirtualization.HostPool, 0)
+	for output.NotDone() {
+
+		for _, res := range output.Values() {
+			resources = append(resources, res)
+		}
+
+		if err := output.NextWithContext(ctx); err != nil {
+			break
+		}
+	}
+	return resources, nil
+}
+
+// ListApplicationGroups returns a list of ApplicationGroups within a subscription and a resource group
+func (ar *AzureReader) ListApplicationGroups(ctx context.Context, filter string) ([]desktopvirtualization.ApplicationGroup, error) {
+	client := desktopvirtualization.NewApplicationGroupsClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.ListByResourceGroup(ctx, ar.GetResourceGroupName(), filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list desktopvirtualization.ApplicationGroup from Azure APIs")
+	}
+	resources := make([]desktopvirtualization.ApplicationGroup, 0)
+	for output.NotDone() {
+
+		for _, res := range output.Values() {
+			resources = append(resources, res)
+		}
+
+		if err := output.NextWithContext(ctx); err != nil {
+			break
+		}
+	}
+	return resources, nil
+}
+
+// ListWorkflows returns a list of Workflows within a subscription and a resource group
+func (ar *AzureReader) ListWorkflows(ctx context.Context, top *int32, filter string) ([]logic.Workflow, error) {
+	client := logic.NewWorkflowsClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.ListByResourceGroup(ctx, ar.GetResourceGroupName(), top, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list logic.Workflow from Azure APIs")
+	}
+	resources := make([]logic.Workflow, 0)
+	for output.NotDone() {
+
+		for _, res := range output.Values() {
+			resources = append(resources, res)
+		}
+
+		if err := output.NextWithContext(ctx); err != nil {
+			break
+		}
+	}
+	return resources, nil
+}
+
+// ListWorkflowTriggers returns a list of WorkflowTriggers within a subscription and a resource group
+func (ar *AzureReader) ListWorkflowTriggers(ctx context.Context, workflowName string, top *int32, filter string) ([]logic.WorkflowTrigger, error) {
+	client := logic.NewWorkflowTriggersClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.List(ctx, ar.GetResourceGroupName(), workflowName, top, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list logic.WorkflowTrigger from Azure APIs")
+	}
+	resources := make([]logic.WorkflowTrigger, 0)
+	for output.NotDone() {
+
+		for _, res := range output.Values() {
+			resources = append(resources, res)
+		}
+
+		if err := output.NextWithContext(ctx); err != nil {
+			break
+		}
+	}
+	return resources, nil
+}
+
+// ListWorkflowRuns returns a list of WorkflowRuns within a subscription and a resource group
+func (ar *AzureReader) ListWorkflowRuns(ctx context.Context, workflowName string, top *int32, filter string) ([]logic.WorkflowRun, error) {
+	client := logic.NewWorkflowRunsClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.List(ctx, ar.GetResourceGroupName(), workflowName, top, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list logic.WorkflowRun from Azure APIs")
+	}
+	resources := make([]logic.WorkflowRun, 0)
+	for output.NotDone() {
+
+		for _, res := range output.Values() {
+			resources = append(resources, res)
+		}
+
+		if err := output.NextWithContext(ctx); err != nil {
+			break
+		}
+	}
+	return resources, nil
+}
+
+// ListWorkflowRunActions returns a list of WorkflowRunActions within a subscription and a resource group
+func (ar *AzureReader) ListWorkflowRunActions(ctx context.Context, workflowName string, runName string, top *int32, filter string) ([]logic.WorkflowRunAction, error) {
+	client := logic.NewWorkflowRunActionsClient(ar.config.SubscriptionID)
+	client.Authorizer = ar.authorizer
+
+	output, err := client.List(ctx, ar.GetResourceGroupName(), workflowName, runName, top, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list logic.WorkflowRunAction from Azure APIs")
+	}
+	resources := make([]logic.WorkflowRunAction, 0)
 	for output.NotDone() {
 
 		for _, res := range output.Values() {

--- a/azurerm/resources.go
+++ b/azurerm/resources.go
@@ -19,6 +19,7 @@ const (
 	Subnet
 	VirtualDesktopHostPool
 	VirtualDesktopApplicationGroup
+	LogicAppTriggerCustom
 	LogicAppWorkflow
 	NetworkInterface
 	NetworkSecurityGroup
@@ -35,6 +36,7 @@ var (
 		VirtualMachine:                 virtualMachines,
 		VirtualNetwork:                 cacheVirtualNetworks,
 		Subnet:                         subnets,
+		LogicAppTriggerCustom:          logicAppTriggerCustoms,
 		LogicAppWorkflow:               logicAppWorkflows,
 		NetworkInterface:               networkInterfaces,
 		NetworkSecurityGroup:           networkSecurityGroups,
@@ -177,6 +179,26 @@ func logicAppWorkflows(ctx context.Context, a *azurerm, resourceType string, fil
 	for _, appWorklow := range appWorkflows {
 		r := provider.NewResource(*appWorklow.ID, resourceType, a)
 		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func logicAppTriggerCustoms(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	appWorkflows, err := a.azurer.ListWorkflows(ctx, nil, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list logic app workflows from reader")
+	}
+
+	resources := make([]provider.Resource, 0)
+	for _, appWorkflow := range appWorkflows {
+		triggers, err := a.azurer.ListWorkflowTriggers(ctx, *appWorkflow.Name, nil, "")
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to list logic app trigger HTTP requests from reader")
+		}
+		for _, trigger := range triggers {
+			r := provider.NewResource(*trigger.ID, resourceType, a)
+			resources = append(resources, r)
+		}
 	}
 	return resources, nil
 }

--- a/azurerm/resources.go
+++ b/azurerm/resources.go
@@ -19,6 +19,7 @@ const (
 	Subnet
 	VirtualDesktopHostPool
 	VirtualDesktopApplicationGroup
+	LogicAppWorkflow
 	NetworkInterface
 	NetworkSecurityGroup
 	VirtualMachine
@@ -34,6 +35,7 @@ var (
 		VirtualMachine:                 virtualMachines,
 		VirtualNetwork:                 cacheVirtualNetworks,
 		Subnet:                         subnets,
+		LogicAppWorkflow:               logicAppWorkflows,
 		NetworkInterface:               networkInterfaces,
 		NetworkSecurityGroup:           networkSecurityGroups,
 		VirtualMachineScaleSet:         virtualMachineScaleSets,
@@ -161,6 +163,19 @@ func virtualApplicationGroups(ctx context.Context, a *azurerm, resourceType stri
 	resources := make([]provider.Resource, 0, len(applicationGroups))
 	for _, applicationGroup := range applicationGroups {
 		r := provider.NewResource(*applicationGroup.ID, resourceType, a)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func logicAppWorkflows(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	appWorkflows, err := a.azurer.ListWorkflows(ctx, nil, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list logic app workflows from reader")
+	}
+	resources := make([]provider.Resource, 0, len(appWorkflows))
+	for _, appWorklow := range appWorkflows {
+		r := provider.NewResource(*appWorklow.ID, resourceType, a)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/azurerm/resources.go
+++ b/azurerm/resources.go
@@ -16,12 +16,13 @@ type ResourceType int
 //go:generate enumer -type ResourceType -addprefix azurerm_ -transform snake -linecomment
 const (
 	ResourceGroup ResourceType = iota
-	VirtualMachine
-	VirtualNetwork
 	Subnet
+	VirtualDesktopHostPool
 	NetworkInterface
 	NetworkSecurityGroup
+	VirtualMachine
 	VirtualMachineScaleSet
+	VirtualNetwork
 )
 
 type rtFn func(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error)
@@ -35,6 +36,7 @@ var (
 		NetworkInterface:       networkInterfaces,
 		NetworkSecurityGroup:   networkSecurityGroups,
 		VirtualMachineScaleSet: virtualMachineScaleSets,
+		VirtualDesktopHostPool: virtualDesktopHostPools,
 	}
 )
 
@@ -129,6 +131,19 @@ func virtualMachineScaleSets(ctx context.Context, a *azurerm, resourceType strin
 	resources := make([]provider.Resource, 0, len(virtualMachineScaleSets))
 	for _, virtualMachineScaleSet := range virtualMachineScaleSets {
 		r := provider.NewResource(*virtualMachineScaleSet.ID, resourceType, a)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func virtualDesktopHostPools(ctx context.Context, a *azurerm, resourceType string, filters *filter.Filter) ([]provider.Resource, error) {
+	pools, err := a.azurer.ListHostPools(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list host pools from reader")
+	}
+	resources := make([]provider.Resource, 0, len(pools))
+	for _, hostPool := range pools {
+		r := provider.NewResource(*hostPool.ID, resourceType, a)
 		resources = append(resources, r)
 	}
 	return resources, nil

--- a/azurerm/resourcetype_enumer.go
+++ b/azurerm/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "azurerm_resource_groupazurerm_virtual_machineazurerm_virtual_networkazurerm_subnetazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machine_scale_set"
+const _ResourceTypeName = "azurerm_resource_groupazurerm_subnetazurerm_virtual_desktop_host_poolazurerm_virtual_desktop_application_groupazurerm_logic_app_action_customazurerm_logic_app_trigger_customazurerm_logic_app_workflowazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machineazurerm_virtual_machine_scale_setazurerm_virtual_network"
 
-var _ResourceTypeIndex = [...]uint8{0, 22, 45, 68, 82, 107, 137, 170}
+var _ResourceTypeIndex = [...]uint16{0, 22, 36, 69, 110, 141, 173, 199, 224, 254, 277, 310, 333}
 
-const _ResourceTypeLowerName = "azurerm_resource_groupazurerm_virtual_machineazurerm_virtual_networkazurerm_subnetazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machine_scale_set"
+const _ResourceTypeLowerName = "azurerm_resource_groupazurerm_subnetazurerm_virtual_desktop_host_poolazurerm_virtual_desktop_application_groupazurerm_logic_app_action_customazurerm_logic_app_trigger_customazurerm_logic_app_workflowazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machineazurerm_virtual_machine_scale_setazurerm_virtual_network"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,33 +19,48 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:22]:         0,
 	_ResourceTypeLowerName[0:22]:    0,
-	_ResourceTypeName[22:45]:        1,
-	_ResourceTypeLowerName[22:45]:   1,
-	_ResourceTypeName[45:68]:        2,
-	_ResourceTypeLowerName[45:68]:   2,
-	_ResourceTypeName[68:82]:        3,
-	_ResourceTypeLowerName[68:82]:   3,
-	_ResourceTypeName[82:107]:       4,
-	_ResourceTypeLowerName[82:107]:  4,
-	_ResourceTypeName[107:137]:      5,
-	_ResourceTypeLowerName[107:137]: 5,
-	_ResourceTypeName[137:170]:      6,
-	_ResourceTypeLowerName[137:170]: 6,
+	_ResourceTypeName[22:36]:        1,
+	_ResourceTypeLowerName[22:36]:   1,
+	_ResourceTypeName[36:69]:        2,
+	_ResourceTypeLowerName[36:69]:   2,
+	_ResourceTypeName[69:110]:       3,
+	_ResourceTypeLowerName[69:110]:  3,
+	_ResourceTypeName[110:141]:      4,
+	_ResourceTypeLowerName[110:141]: 4,
+	_ResourceTypeName[141:173]:      5,
+	_ResourceTypeLowerName[141:173]: 5,
+	_ResourceTypeName[173:199]:      6,
+	_ResourceTypeLowerName[173:199]: 6,
+	_ResourceTypeName[199:224]:      7,
+	_ResourceTypeLowerName[199:224]: 7,
+	_ResourceTypeName[224:254]:      8,
+	_ResourceTypeLowerName[224:254]: 8,
+	_ResourceTypeName[254:277]:      9,
+	_ResourceTypeLowerName[254:277]: 9,
+	_ResourceTypeName[277:310]:      10,
+	_ResourceTypeLowerName[277:310]: 10,
+	_ResourceTypeName[310:333]:      11,
+	_ResourceTypeLowerName[310:333]: 11,
 }
 
 var _ResourceTypeNames = []string{
 	_ResourceTypeName[0:22],
-	_ResourceTypeName[22:45],
-	_ResourceTypeName[45:68],
-	_ResourceTypeName[68:82],
-	_ResourceTypeName[82:107],
-	_ResourceTypeName[107:137],
-	_ResourceTypeName[137:170],
+	_ResourceTypeName[22:36],
+	_ResourceTypeName[36:69],
+	_ResourceTypeName[69:110],
+	_ResourceTypeName[110:141],
+	_ResourceTypeName[141:173],
+	_ResourceTypeName[173:199],
+	_ResourceTypeName[199:224],
+	_ResourceTypeName[224:254],
+	_ResourceTypeName[254:277],
+	_ResourceTypeName[277:310],
+	_ResourceTypeName[310:333],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/azurerm/resourcetype_enumer.go
+++ b/azurerm/resourcetype_enumer.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-const _ResourceTypeName = "azurerm_resource_groupazurerm_subnetazurerm_virtual_desktop_host_poolazurerm_virtual_desktop_application_groupazurerm_logic_app_action_customazurerm_logic_app_trigger_customazurerm_logic_app_workflowazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machineazurerm_virtual_machine_scale_setazurerm_virtual_network"
+const _ResourceTypeName = "azurerm_resource_groupazurerm_subnetazurerm_virtual_desktop_host_poolazurerm_virtual_desktop_application_groupazurerm_logic_app_trigger_customazurerm_logic_app_action_customazurerm_logic_app_workflowazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machineazurerm_virtual_machine_extensionazurerm_virtual_machine_scale_setazurerm_virtual_network"
 
-var _ResourceTypeIndex = [...]uint16{0, 22, 36, 69, 110, 141, 173, 199, 224, 254, 277, 310, 333}
+var _ResourceTypeIndex = [...]uint16{0, 22, 36, 69, 110, 142, 173, 199, 224, 254, 277, 310, 343, 366}
 
-const _ResourceTypeLowerName = "azurerm_resource_groupazurerm_subnetazurerm_virtual_desktop_host_poolazurerm_virtual_desktop_application_groupazurerm_logic_app_action_customazurerm_logic_app_trigger_customazurerm_logic_app_workflowazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machineazurerm_virtual_machine_scale_setazurerm_virtual_network"
+const _ResourceTypeLowerName = "azurerm_resource_groupazurerm_subnetazurerm_virtual_desktop_host_poolazurerm_virtual_desktop_application_groupazurerm_logic_app_trigger_customazurerm_logic_app_action_customazurerm_logic_app_workflowazurerm_network_interfaceazurerm_network_security_groupazurerm_virtual_machineazurerm_virtual_machine_extensionazurerm_virtual_machine_scale_setazurerm_virtual_network"
 
 func (i ResourceType) String() string {
 	if i < 0 || i >= ResourceType(len(_ResourceTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i ResourceType) String() string {
 	return _ResourceTypeName[_ResourceTypeIndex[i]:_ResourceTypeIndex[i+1]]
 }
 
-var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+var _ResourceTypeValues = []ResourceType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
 var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeName[0:22]:         0,
@@ -30,10 +30,10 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[36:69]:   2,
 	_ResourceTypeName[69:110]:       3,
 	_ResourceTypeLowerName[69:110]:  3,
-	_ResourceTypeName[110:141]:      4,
-	_ResourceTypeLowerName[110:141]: 4,
-	_ResourceTypeName[141:173]:      5,
-	_ResourceTypeLowerName[141:173]: 5,
+	_ResourceTypeName[110:142]:      4,
+	_ResourceTypeLowerName[110:142]: 4,
+	_ResourceTypeName[142:173]:      5,
+	_ResourceTypeLowerName[142:173]: 5,
 	_ResourceTypeName[173:199]:      6,
 	_ResourceTypeLowerName[173:199]: 6,
 	_ResourceTypeName[199:224]:      7,
@@ -44,8 +44,10 @@ var _ResourceTypeNameToValueMap = map[string]ResourceType{
 	_ResourceTypeLowerName[254:277]: 9,
 	_ResourceTypeName[277:310]:      10,
 	_ResourceTypeLowerName[277:310]: 10,
-	_ResourceTypeName[310:333]:      11,
-	_ResourceTypeLowerName[310:333]: 11,
+	_ResourceTypeName[310:343]:      11,
+	_ResourceTypeLowerName[310:343]: 11,
+	_ResourceTypeName[343:366]:      12,
+	_ResourceTypeLowerName[343:366]: 12,
 }
 
 var _ResourceTypeNames = []string{
@@ -53,14 +55,15 @@ var _ResourceTypeNames = []string{
 	_ResourceTypeName[22:36],
 	_ResourceTypeName[36:69],
 	_ResourceTypeName[69:110],
-	_ResourceTypeName[110:141],
-	_ResourceTypeName[141:173],
+	_ResourceTypeName[110:142],
+	_ResourceTypeName[142:173],
 	_ResourceTypeName[173:199],
 	_ResourceTypeName[199:224],
 	_ResourceTypeName[224:254],
 	_ResourceTypeName[254:277],
 	_ResourceTypeName[277:310],
-	_ResourceTypeName[310:333],
+	_ResourceTypeName[310:343],
+	_ResourceTypeName[343:366],
 }
 
 // ResourceTypeString retrieves an enum value from the enum constants string name.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.35.9
 	github.com/chr4/pwgen v1.1.0
-	github.com/cycloidio/tfdocs v0.0.0-20200111145532-e6a80a93d7cc
+	github.com/cycloidio/tfdocs v0.0.0-20201106154358-49ea9e6f45e4
 	github.com/go-kit/kit v0.9.0
 	github.com/golang/mock v1.4.4
 	github.com/hashicorp/go-azure-helpers v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cycloidio/terraform v0.13.5-cy h1:SFRumRQiIQ83RmA5e52q8PJ3VjSBzk+ZVtyVypBaxDs=
 github.com/cycloidio/terraform v0.13.5-cy/go.mod h1:1H1qcnppNc/bBGc7poOfnmmBeQMlF0stEN3haY3emCU=
-github.com/cycloidio/tfdocs v0.0.0-20200111145532-e6a80a93d7cc h1:wJpFr2AiXfsVCCBPOYQUYvEfT+2cAgCuipgfB9hoXVw=
-github.com/cycloidio/tfdocs v0.0.0-20200111145532-e6a80a93d7cc/go.mod h1:FKvkOvkwOg6hl3uyCnNbLiANc6BMD/ljQAU8Nf8/X8E=
+github.com/cycloidio/tfdocs v0.0.0-20201106154358-49ea9e6f45e4 h1:MaRqoSVnOhK9aDUXHbpPlwUXDph4cJEKGkwXbfYuJ0M=
+github.com/cycloidio/tfdocs v0.0.0-20201106154358-49ea9e6f45e4/go.mod h1:FKvkOvkwOg6hl3uyCnNbLiANc6BMD/ljQAU8Nf8/X8E=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/mock/writer.go
+++ b/mock/writer.go
@@ -7,7 +7,6 @@ package mock
 import (
 	reflect "reflect"
 
-	writer "github.com/cycloidio/terracognita/writer"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -32,20 +31,6 @@ func NewWriter(ctrl *gomock.Controller) *Writer {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *Writer) EXPECT() *WriterMockRecorder {
 	return m.recorder
-}
-
-// GetOptions mocks base method
-func (m *Writer) GetOptions() *writer.Options {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOptions")
-	ret0, _ := ret[0].(*writer.Options)
-	return ret0
-}
-
-// GetOptions indicates an expected call of GetOptions
-func (mr *WriterMockRecorder) GetOptions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*Writer)(nil).GetOptions))
 }
 
 // Has mocks base method


### PR DESCRIPTION
In this PR, we add some AzureRM resources for WVD. In complement of the resources, I modified the AzureRM generation parts:

- add a new struct `ExtraArgs` to handle different types of args (only `string` was supported). First; I tried with a `map[string]string` but it's not deterministic
- add a new field to the `APIVersion` to support `preview` mode
- `tfdocs` bumped to the latest version to support VD resources

Added resources:
- VirtualDesktopHostPool
- VirtualDesktopApplicationGroup
- LogicAppActionCustom
- LogicAppWorkflow
- LogicAppTriggerCustom
- VirtualMachineExtension