### PR TITLE
doc: udpate download to get latest release [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Providers:
 
 ### Binary
 
-Visit the [releases](https://github.com/cycloidio/terracognita/releases) page to select your system, architecture and version you need. Then:
+Visit the [releases](https://github.com/cycloidio/terracognita/releases) page to select your system, architecture and version you need. To pull the latest release:
 
 ```shell
-$ curl -L https://github.com/cycloidio/terracognita/releases/download/v0.5.1/terracognita-linux-amd64.tar.gz -o terracognita-linux-amd64.tar.gz
+$ curl -L https://github.com/cycloidio/terracognita/releases/latest/download/terracognita-linux-amd64.tar.gz -o terracognita-linux-amd64.tar.gz
 $ tar -xf terracognita-linux-amd64.tar.gz
 $ chmod u+x terracognita-linux-amd64
 $ sudo mv terracognita-linux-amd64 /usr/local/bin/terracognita


### PR DESCRIPTION
it will avoid to maintain readme for each new release