### PR TITLE
aws: provide support for `AWS_SESSION_TOKEN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   ([PR #145](https://github.com/cycloidio/terracognita/pull/145))
 - Log File to always write the last -v logs to
   ([Issue #149](https://github.com/cycloidio/terracognita/issues/149))
+- Authentication using AWS session token
+  ([Issue #154](https://github.com/cycloidio/terracognita/issues/154))
 
 ### Changed
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -35,9 +35,9 @@ type aws struct {
 }
 
 // NewProvider returns an AWS Provider
-func NewProvider(ctx context.Context, accessKey, secretKey, region string) (provider.Provider, error) {
+func NewProvider(ctx context.Context, accessKey, secretKey, region, sessionToken string) (provider.Provider, error) {
 	log.Get().Log("func", "reader.New", "msg", "configuring aws Reader")
-	awsr, err := reader.New(ctx, accessKey, secretKey, region, nil)
+	awsr, err := reader.New(ctx, accessKey, secretKey, region, sessionToken, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize 'reader' because: %s", err)
 	}
@@ -46,6 +46,7 @@ func NewProvider(ctx context.Context, accessKey, secretKey, region string) (prov
 		AccessKey: accessKey,
 		SecretKey: secretKey,
 		Region:    region,
+		Token:     sessionToken,
 	}
 
 	log.Get().Log("func", "aws.NewProvider", "msg", "configuring TF Client")

--- a/aws/reader/connector.go
+++ b/aws/reader/connector.go
@@ -45,10 +45,10 @@ import (
 // See:
 //  * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors
 //  * https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
-func New(ctx context.Context, accessKey string, secretKey string, region string, config *aws.Config) (Reader, error) {
+func New(ctx context.Context, accessKey string, secretKey string, region string, sessionToken string, config *aws.Config) (Reader, error) {
 	var c = connector{}
 
-	creds, ec2s, sts, err := configureAWS(accessKey, secretKey)
+	creds, ec2s, sts, err := configureAWS(accessKey, secretKey, sessionToken)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ type serviceConnector struct {
 // a Security Token Service client.
 // The only AWS error code that this function return is
 // * EmptyStaticCreds
-func configureAWS(accessKey string, secretKey string) (*credentials.Credentials, ec2iface.EC2API, stsiface.STSAPI, error) {
+func configureAWS(accessKey, secretKey, token string) (*credentials.Credentials, ec2iface.EC2API, stsiface.STSAPI, error) {
 	/* The default region is only used to (1) get the list of region and
 	 * (2) get the account ID associated with the credentials.
 	 *
@@ -124,7 +124,6 @@ func configureAWS(accessKey string, secretKey string) (*credentials.Credentials,
 	 * not try to establish any connections with AWS services.
 	 */
 	const defaultRegion string = "eu-west-1"
-	var token = ""
 
 	creds := credentials.NewStaticCredentials(accessKey, secretKey, token)
 	_, err := creds.Get()

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -35,6 +35,7 @@ var (
 			viper.BindPFlag("aws-access-key", cmd.Flags().Lookup("aws-access-key"))
 			viper.BindPFlag("aws-secret-access-key", cmd.Flags().Lookup("aws-secret-access-key"))
 			viper.BindPFlag("aws-default-region", cmd.Flags().Lookup("aws-default-region"))
+			viper.BindPFlag("aws-session-token", cmd.Flags().Lookup("aws-session-token"))
 
 			viper.BindPFlag("aws-shared-credentials-file", cmd.Flags().Lookup("aws-shared-credentials-file"))
 			viper.BindPFlag("aws-profile", cmd.Flags().Lookup("aws-profile"))
@@ -44,6 +45,7 @@ var (
 			// We define aliases so we have an easier access on the code
 			viper.RegisterAlias("access-key", "aws-access-key")
 			viper.RegisterAlias("secret-key", "aws-secret-key")
+			viper.RegisterAlias("session-token", "aws-session-token")
 			viper.RegisterAlias("region", "aws-default-region")
 		},
 		PostRunE: postRunEOutput,
@@ -70,7 +72,7 @@ var (
 
 			ctx := context.Background()
 
-			awsP, err := aws.NewProvider(ctx, viper.GetString("access-key"), viper.GetString("secret-key"), viper.GetString("region"))
+			awsP, err := aws.NewProvider(ctx, viper.GetString("access-key"), viper.GetString("secret-key"), viper.GetString("region"), viper.GetString("session-token"))
 			if err != nil {
 				return err
 			}
@@ -115,6 +117,7 @@ func init() {
 	// Required flags
 	awsCmd.Flags().String("aws-access-key", "", "Access Key (required)")
 	awsCmd.Flags().String("aws-secret-access-key", "", "Secret Key (required)")
+	awsCmd.Flags().String("aws-session-token", "", "Use to validate the temporary security credentials")
 	awsCmd.Flags().String("aws-default-region", "", "Region to search in, for now * is not supported (required)")
 	awsCmd.Flags().String("aws-shared-credentials-file", "", "Path to the AWS credential path")
 	awsCmd.Flags().String("aws-profile", "", "Name of the Profile to use with the Credentials")
@@ -154,6 +157,10 @@ func loadAWSCredentials() error {
 
 	if !viper.IsSet("secret-key") {
 		viper.Set("secret-key", value.SecretAccessKey)
+	}
+
+	if !viper.IsSet("session-token") {
+		viper.Set("session-token", value.SessionToken)
 	}
 
 	return nil

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -44,7 +44,7 @@ var (
 
 			// We define aliases so we have an easier access on the code
 			viper.RegisterAlias("access-key", "aws-access-key")
-			viper.RegisterAlias("secret-key", "aws-secret-key")
+			viper.RegisterAlias("secret-key", "aws-secret-access-key")
 			viper.RegisterAlias("session-token", "aws-session-token")
 			viper.RegisterAlias("region", "aws-default-region")
 		},


### PR DESCRIPTION
In the case of credentials generated by STS,we need to provide a `session-token` in complement of the required keys (access & secret). Before this PR, the token was set to a default empty string.

In this PR, we add a dedicated flag `--aws-session-token`. This flag can be set explicitly or it can be populated using `AWS_SESSION_TOKEN` (see [there](https://github.com/cycloidio/terracognita/issues/154#issuecomment-743351661) why).

Closes: https://github.com/cycloidio/terracognita/issues/154