### PR TITLE
aws: fix IOpS import on ebs / aws_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- AWS IOpS attribute is only valid for io1 and io2 type
+  ([Issue #157](https://github.com/cycloidio/terracognita/issues/157))
+
 ## [0.6.0] _2020-12-22_
 
 ### Added

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -99,9 +99,13 @@ func (w *Writer) Has(key string) (bool, error) {
 // Sync writes the content of the Config to the
 // internal w with the correct format
 func (w *Writer) Sync() error {
-	if err := w.opts.PreSync(w.Config["resource"]); err != nil {
-		return fmt.Errorf("unable to pre-sync the HCL configuration: %w", err)
+
+	if w.opts.PreSync != nil {
+		if err := w.opts.PreSync(w.Config["resource"]); err != nil {
+			return fmt.Errorf("unable to pre-sync the HCL configuration: %w", err)
+		}
 	}
+
 	logger := log.Get()
 	logger = kitlog.With(logger, "func", "writer.Write(HCL)")
 

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -99,6 +99,9 @@ func (w *Writer) Has(key string) (bool, error) {
 // Sync writes the content of the Config to the
 // internal w with the correct format
 func (w *Writer) Sync() error {
+	if err := w.opts.PreSync(w.Config["resource"]); err != nil {
+		return fmt.Errorf("unable to pre-sync the HCL configuration: %w", err)
+	}
 	logger := log.Get()
 	logger = kitlog.With(logger, "func", "writer.Write(HCL)")
 

--- a/writer/options.go
+++ b/writer/options.go
@@ -6,4 +6,8 @@ type Options struct {
 	// variables in HCL files or building dependencies
 	// in a TFState
 	Interpolate bool
+
+	// PreSync is the method to call before the `Sync`
+	// of the writer in order to perform surgicals modification
+	PreSync func(interface{}) error
 }


### PR DESCRIPTION
The attribute `iops` can't be set if the volume type is `gp2` but it has to be present in the `tfstate`. A `PreSync` writer option has been added in order to perform this. Developer needs to implement this option for a provider if we wants to modify on the fly the HCL configuration following particular needs.

Closes: https://github.com/cycloidio/terracognita/issues/157