### PR TITLE
[CI SKIP] release: fix AUR release

### DIFF
--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -517,7 +517,7 @@ jobs:
                 args:
                   - '-c'
                   - |
-                    apk add --update --no-progress git jq curl wget sed
+                    apk add --update --no-progress git jq curl wget sed openssh
                     sh master/scripts/deploy/aur.sh
               inputs:
                 - name: ((branch))

--- a/scripts/deploy/aur.sh
+++ b/scripts/deploy/aur.sh
@@ -44,7 +44,7 @@ sha256sum_amd64=$(sha256sum terracognita-linux-amd64.tar.gz | awk '{ print $1 }'
 echo "$SSH_PRIVATE_KEY" > id_rsa.aur; chmod 600 ./id_rsa.aur
 
 # clone the actual AUR
-GIT_SSH_COMMAND="ssh -i ./id_rsa.aur" git clone ssh://aur@aur.archlinux.org/terracognita.git && cd terracognita
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i ./id_rsa.aur" git clone ssh://aur@aur.archlinux.org/terracognita.git && cd terracognita
 
 # update the manifests (PKGBUILD and .SRCINFO)
 # update the package version, the URLs and the sha256sums
@@ -62,11 +62,15 @@ sed -i "s/pkgver = [^\"]*/pkgver = ${tag_name:1}/" .SRCINFO
 # show git diff
 git --no-pager diff
 
+# configure git
+git config --global user.name "cycloid"
+git config --global user.email "cycloid@build"
+
 # commit the files
 # TODO: sign the commit by the CI
 git commit -am "terracognita: bump to version $tag_name"
 
 # push the files
-GIT_SSH_COMMAND="ssh -i ../id_rsa.aur" git push -u origin master
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i ../id_rsa.aur" git push -u origin master
 
 cd ../; rm -rf terracognita* id_rsa.aur


### PR DESCRIPTION
a couple of elements were missing to publish on the AUR:

- ssh client to git clone
- host key checking
- git identity

result: https://aur.archlinux.org/cgit/aur.git/commit/?h=terracognita&id=b8ef1c04b36df5b1ffbe4582656d3b045cf78444

NB: pipeline has been refreshed.
