### PR TITLE
hcl: Fixed issue with empty arrays and modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Empty array values on modules now are generated correctly and not failing
+  ([PR #174](https://github.com/cycloidio/terracognita/pull/174))
+
 ## [0.6.2] _2021-03-18_
 
 We had an error on the Pipeline of the last release so we made a quick patch release to fix it

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -149,6 +149,7 @@ resource "type" "name" {
 			value2 = map[string]interface{}{
 				"key":  "value",
 				"key2": "value",
+				"key3": []interface{}{},
 			}
 			hcl = `
 resource "type" "name" {
@@ -158,11 +159,13 @@ resource "type" "name" {
 resource "type" "name2" {
   key = var.type_name2_key
 	key2 = var.type_name2_key2
+	key3 = var.type_name2_key3
 }
 
 module "test" {
 	# type_name2_key = "value"
 	# type_name2_key2 = "value"
+	# type_name2_key3 = []
 	# type_name_key = "value"
   source = "module-test"
 }
@@ -173,6 +176,10 @@ variable "type_name2_key" {
 
 variable "type_name2_key2" {
 	default = "value"
+}
+
+variable "type_name2_key3" {
+	default = []
 }
 
 variable "type_name_key" {


### PR DESCRIPTION
It was always trying to access the first element and not checking if it was empty before. Now it'll check and if it's empty it'll directly use a variable for it