### PR TITLE
README: Remove the image from the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ At [Cycloid](https://www.cycloid.io/), Infrastructure As Code is in the company 
 
 We decided to Open Source this tool as we believe that it will help people to adopt IaC in an easy way. Cycloid provides this tool to let people import their infrastructure into [Cycloid's pipelines](https://www.cycloid.io/devops-framework), allow them to generate infrastructure diagram and manage all infra/application life cycle from a single interface.
 
-If you are interested in contributing to Terracognita or simply curious about what's next, take a look at the public [roadmap](https://github.com/cycloidio/terracognita/issues/118). For a high level overview, check out the [What is Terracognita?](https://blog.cycloid.io/what-is-terracognita) blogpost or watch the video below.
-
-<p align="center">
-  <img src="https://img.youtube.com/vi/PtJgf7AWBVA/0.jpg" alt="TerraCognita - the reverse Terraform tool">
-</p>
+If you are interested in contributing to Terracognita or simply curious about what's next, take a look at the public [roadmap](https://github.com/cycloidio/terracognita/issues/118). For a high level overview, check out the [What is Terracognita?](https://blog.cycloid.io/what-is-terracognita) blogpost or watch this [video](https://www.youtube.com/watch?v=PtJgf7AWBVA).
 
 ## Cloud providers
 


### PR DESCRIPTION
It was too invasive for what the tool actually is and it does not provide information on how to use it
only on how it works and on the README we should have info on how to use it