### PR TITLE
cmd: Fix error with the '--labels' flag not used on Google

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- `--labels` flag is correctly read now on Google CMD
+
 ## [0.6.3] _2021-03-30_
 
 ### Fixed

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -68,11 +66,11 @@ var (
 			// Initialize the tags
 			tags := make([]tag.Tag, 0, len(viper.GetStringSlice("tags")))
 			for _, t := range viper.GetStringSlice("tags") {
-				values := strings.Split(t, ":")
-				if len(values) != 2 {
-					return errors.New("invalid format for --tags, the expected format is 'NAME:VALUE'")
+				tg, err := tag.New(t)
+				if err != nil {
+					return fmt.Errorf("invalid format for --tags with value %q: %w", t, err)
 				}
-				tags = append(tags, tag.Tag{Name: values[0], Value: values[1]})
+				tags = append(tags, tg)
 			}
 
 			ctx := context.Background()

--- a/cmd/google.go
+++ b/cmd/google.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -48,13 +47,13 @@ var (
 			}
 
 			// Initialize the tags
-			tags := make([]tag.Tag, 0, len(viper.GetStringSlice("tags")))
-			for _, t := range viper.GetStringSlice("tags") {
-				values := strings.Split(t, ":")
-				if len(values) != 2 {
-					return errors.New("invalid format for --tags, the expected format is 'NAME:VALUE'")
+			tags := make([]tag.Tag, 0, len(viper.GetStringSlice("labels")))
+			for _, t := range viper.GetStringSlice("labels") {
+				tg, err := tag.New(t)
+				if err != nil {
+					return fmt.Errorf("invalid format for --labels with value %q: %w", t, err)
 				}
-				tags = append(tags, tag.Tag{Name: values[0], Value: values[1]})
+				tags = append(tags, tg)
 			}
 
 			ctx := context.Background()

--- a/errcode/codes.go
+++ b/errcode/codes.go
@@ -20,6 +20,8 @@ var (
 
 	ErrFilterTargetsInvalid = errors.New("the filter targets has an invalid format")
 
+	ErrTagInvalidForamt = errors.New("invalid format for tag, the expected format is 'NAME:VALUE'")
+
 	// ErrProviderAPI will be raised when an error occurs provider side while
 	// using its APIs (authorization error, unavailable operation, ...)
 	ErrProviderAPI = errors.New("error while requesting the provider APIs")

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -3,10 +3,12 @@ package tag
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/chr4/pwgen"
+	"github.com/cycloidio/terracognita/errcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -19,6 +21,15 @@ var nameRegexp = regexp.MustCompile(`^[a-z0-9_]+$`)
 type Tag struct {
 	Name  string
 	Value string
+}
+
+// New initializes a tag with the format NAME:VALUE that we use
+func New(t string) (Tag, error) {
+	values := strings.Split(t, ":")
+	if len(values) != 2 {
+		return Tag{}, errcode.ErrTagInvalidForamt
+	}
+	return Tag{Name: values[0], Value: values[1]}, nil
 }
 
 // ToEC2Filter transforms the Tag to a ec2.Filter

--- a/tag/tag_test.go
+++ b/tag/tag_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/tag"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,46 @@ func TestToEC2Filer(t *testing.T) {
 			Values: []*string{aws.String("tag-value")},
 		}, tt.ToEC2Filter())
 	})
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		Name  string
+		STag  string
+		ETag  tag.Tag
+		Error bool
+	}{
+		{
+			Name: "Success",
+			STag: "key:val",
+			ETag: tag.Tag{Name: "key", Value: "val"},
+		},
+		{
+			Name:  "ErrorEmpty",
+			STag:  "",
+			Error: true,
+		},
+		{
+			Name:  "ErrorNoSeparator",
+			STag:  "key",
+			Error: true,
+		},
+		{
+			Name:  "ErrorMoreThanOneSeparator",
+			STag:  "key:value:what",
+			Error: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			tg, err := tag.New(tt.STag)
+			if tt.Error {
+				assert.EqualError(t, err, errcode.ErrTagInvalidForamt.Error())
+			}
+			assert.Equal(t, tt.ETag, tg)
+		})
+	}
 }
 
 func TestGetNameFromTag(t *testing.T) {


### PR DESCRIPTION
Also abstracted the logic to validate the Tags to the 'tag' package
with the new 'tag.New' so it can be reused