### PR TITLE
aws: Changed from Message to Code check on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## [Unreleased]
 
+### Changed
+
+- AWS error handling from Message to Code and added 'AccessDeniedException'
+  ([Issue #171](https://github.com/cycloidio/terracognita/issues/171))
+
 ### Fixed
 
 - `--labels` flag is correctly read now on Google CMD
+  ([PR #180](https://github.com/cycloidio/terracognita/pull/180))
 
 ## [0.6.3] _2021-03-30_
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -16,13 +16,14 @@ import (
 	tfaws "github.com/terraform-providers/terraform-provider-aws/aws"
 )
 
-// skippableErrors is a list of errors
+// skippableCodes is a list of codes
 // which won't make Terracognita failed
 // but they will be printed on the output
-// they are based on the err.Message() content
+// they are based on the err.Code() content
 // of the AWS error
-var skippableErrors = map[string]struct{}{
-	"Unavailable Operation": struct{}{},
+var skippableCodes = map[string]struct{}{
+	"InvalidAction":         struct{}{},
+	"AccessDeniedException": struct{}{},
 }
 
 type aws struct {
@@ -86,7 +87,7 @@ func (a *aws) Resources(ctx context.Context, t string, f *filter.Filter) ([]prov
 		// we filter the error from AWS and return a custom error
 		// type if it's an error that we want to skip
 		if reqErr, ok := err.(awserr.RequestFailure); ok {
-			if _, ok := skippableErrors[reqErr.Message()]; ok {
+			if _, ok := skippableCodes[reqErr.Code()]; ok {
 				return nil, fmt.Errorf("%w: %v", errcode.ErrProviderAPI, reqErr)
 			}
 		}


### PR DESCRIPTION
And added a new one to the list 'AccessDeniedException'

To make the change on the Error handling I checked which was the error we had to fix on https://github.com/cycloidio/terracognita/issues/138 and checked the code from AWS to format errors so I knew which Code to expect.

Closes #176