### PR TITLE
aws: fix #171 RequestError when service not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - aws resources: `aws_eip`, `aws_dynamodb_global_table`, `aws_dynamodb_table`, `aws_ecs_cluster`, `aws_ecs_service`, `aws_athena_workgroup`, `aws_glue_catalog_database`, `aws_glue_catalog_table`, `aws_fsx_lustre_file_system`, `aws_batch_job_definition`, `aws_dax_cluster`, `aws_directory_service_directory`, `aws_dms_replication_instance`, `aws_dx_gateway`, `aws_efs_file_system`, `aws_eks_cluster`, `aws_elasticache_replication_group`, `aws_elastic_beanstalk_application`, `aws_emr_cluster`, `aws_internet_gateway`, `aws_kinesis_stream`, `aws_lightsail_instance`, `aws_media_store_container`, `aws_mq_broker`, `aws_nat_gateway`, `aws_neptune_cluster`, `aws_rds_cluster`, `aws_rds_global_cluster`, `aws_redshift_cluster`, `aws_sqs_queue`, `aws_storagegateway_gateway`, `aws_vpn_gateway`.
   ([PR #194](https://github.com/cycloidio/terracognita/pull/194))
 
+### Fixed
+
+- Skip aws `RequestError` errors generaly caused by service not available in a region
+  ([Issue #171](https://github.com/cycloidio/terracognita/pull/171))
+
 ## [0.7.0] _2021-07-02_
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -177,16 +177,21 @@ To speed up the testing, you can write a small `provider.tf`file within the same
 
 ```bash
 terraform {
- backend "local" {
-   path = "./$TFSTATE_PATH"
- }
+  backend "local" {
+    path = "./$TFSTATE_PATH"
+  }
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
 }
 
 provider "aws" {
  access_key = "${var.access_key}"
  secret_key = "${var.secret_key}"
  region     = "${var.region}"
- version    = "2.12.0"
 }
 
 variable "access_key" {}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -24,6 +24,7 @@ import (
 var skippableCodes = map[string]struct{}{
 	"InvalidAction":         struct{}{},
 	"AccessDeniedException": struct{}{},
+	"RequestError":          struct{}{},
 }
 
 type aws struct {
@@ -86,7 +87,7 @@ func (a *aws) Resources(ctx context.Context, t string, f *filter.Filter) ([]prov
 	if err != nil {
 		// we filter the error from AWS and return a custom error
 		// type if it's an error that we want to skip
-		if reqErr, ok := err.(awserr.RequestFailure); ok {
+		if reqErr, ok := err.(awserr.Error); ok {
 			if _, ok := skippableCodes[reqErr.Code()]; ok {
 				return nil, fmt.Errorf("%w: %v", errcode.ErrProviderAPI, reqErr)
 			}

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -275,7 +275,7 @@ func (r *resource) Read(f *filter.Filter) error {
 	// so we have to do it manually
 	// it's not all of them though
 	for _, t := range f.Tags {
-		if v, ok := r.data.GetOk(fmt.Sprintf("%s.%s", r.Provider().TagKey(), t.Name)); ok && v.(string) != t.Value {
+		if v, ok := r.data.GetOk(fmt.Sprintf("%s.%s", r.Provider().TagKey(), t.Name)); !ok || v.(string) != t.Value {
 			return errors.WithStack(errcode.ErrProviderResourceDoNotMatchTag)
 		}
 	}


### PR DESCRIPTION
Skip RequestError raised when there is an issue on network layer.
Mainly happen when a AWS service is not available on the requested region.

+ Update readme regarding new provider.tf format

Fix #171 