### PR TITLE
Fixed: HCL prefixed module source with './'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 ### Fixed
 
 - Skip aws `RequestError` errors generaly caused by service not available in a region
-  ([Issue #171](https://github.com/cycloidio/terracognita/pull/171))
+  ([Issue #171](https://github.com/cycloidio/terracognita/issues/171))
+- Module source now is prefixed with `./` as expected
+  ([PR #209](https://github.com/cycloidio/terracognita/pull/209))
 
 ## [0.7.0] _2021-07-02_
 

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -54,7 +54,7 @@ func NewWriter(w io.Writer, opts *writer.Options) *Writer {
 		cfg[ModuleCategoryKey] = map[string]interface{}{
 			"module": map[string]interface{}{
 				opts.Module: map[string]interface{}{
-					"source": fmt.Sprintf("module-%s", opts.Module),
+					"source": fmt.Sprintf("./module-%s", opts.Module),
 				},
 			},
 		}

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -168,7 +168,7 @@ module "test" {
 	# type_name2_key2 = "value"
 	# type_name2_key3 = []
 	# type_name_key = "value"
-  source = "module-test"
+  source = "./module-test"
 }
 
 variable "type_name2_key" {
@@ -227,7 +227,7 @@ resource "type" "name2" {
 module "test" {
 	# type_name2_key = "value"
 	# type_name_key = "value"
-  source = "module-test"
+  source = "./module-test"
 }
 
 variable "type_name2_key" {


### PR DESCRIPTION
It was required for modules to have it