### PR TITLE
aws: Fixed error of accessing potential null values without validating before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Resource names now are generated removing invalid characters instead just assigning a random alphanumeric value
   ([Issue #208](https://github.com/cycloidio/terracognita/issues/208))
 
+### Fixed
+
+- Import with `aws_alb_target_group_attachment` now validates if the needed values are present
+  ([Issue #213](https://github.com/cycloidio/terracognita/issues/213))
+
 ## [0.7.1] _2021-07-15_
 
 ### Added

--- a/aws/resources.go
+++ b/aws/resources.go
@@ -478,6 +478,11 @@ func albTargetGroupAttachments(ctx context.Context, a *aws, resourceType string,
 		}
 
 		for _, t := range targetHealths {
+			// As this are the required values to get the resource
+			// we validate that they are present
+			if t.Target == nil || i.TargetGroupArn == nil {
+				continue
+			}
 			r, err := initializeResource(a, fmt.Sprintf("%s_%d_%s", *t.Target.Id, *t.Target.Port, *i.TargetGroupArn), resourceType)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION

This was raising null pointer exceptions due to it

Closes #213 