### PR TITLE
tag: Low case all the options for the resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 - Support filter with `tag` attribute used by AWS on `aws_autoscaling_group` resource
   ([Issue #223](https://github.com/cycloidio/terracognita/issues/223))
+- Resource name improved by low casing all the options
+  ([Issue #225](https://github.com/cycloidio/terracognita/issues/225))
+
 
 ## [0.7.2] _2021-08-13_
 

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -68,9 +68,11 @@ func (t Tag) ToNeptuneFilter() *neptune.Filter {
 // Also validates that the 'tags.Name' and fallback are valid, if not it
 // generates a random one
 func GetNameFromTag(key string, srd *schema.ResourceData, fallback string) string {
+	fallback = strings.ToLower(fallback)
+
 	var n string
 	if name, ok := srd.GetOk(fmt.Sprintf("%s.Name", key)); ok {
-		n = name.(string)
+		n = strings.ToLower(name.(string))
 	}
 
 	forcedN := forceResourceName(n)

--- a/tag/tag_test.go
+++ b/tag/tag_test.go
@@ -101,6 +101,13 @@ func TestGetNameFromTag(t *testing.T) {
 			Result:   "res",
 		},
 		{
+			Name:     "WithTagsUpper",
+			Key:      "tags",
+			SRD:      createSRD(t, "tags", tagKey, "Res"),
+			Fallback: "fallback",
+			Result:   "res",
+		},
+		{
 			Name:     "WithTagsButInvalidNameAndEmptyForced",
 			Key:      "tags",
 			SRD:      createSRD(t, "tags", tagKey, "res.res.res"),
@@ -119,6 +126,13 @@ func TestGetNameFromTag(t *testing.T) {
 			Key:      "tags",
 			SRD:      createSRD(t, "tags", "notName", "res"),
 			Fallback: "fallback",
+			Result:   "fallback",
+		},
+		{
+			Name:     "WithTagsButNo'Name'Upper",
+			Key:      "tags",
+			SRD:      createSRD(t, "tags", "notName", "res"),
+			Fallback: "Fallback",
 			Result:   "fallback",
 		},
 		{


### PR DESCRIPTION
So then we'll not have some that are less readable just because they have low case and are replaced

Closes #225 