### PR TITLE
writer: New option HCLProviderBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- New flag `--hcl-provider-block` to be able to opt out of the `provider "" {}` on HCL
+  ([Issue #250](https://github.com/cycloidio/terracognita/issues/250))
+
 ## [0.7.3] _2021-09-23_
 
 ### Changed

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -279,9 +279,10 @@ func getWriterOptions() (*writer.Options, error) {
 	}
 
 	return &writer.Options{
-		Interpolate:     viper.GetBool("interpolate"),
-		Module:          module,
-		ModuleVariables: mv,
+		Interpolate:      viper.GetBool("interpolate"),
+		Module:           module,
+		ModuleVariables:  mv,
+		HCLProviderBlock: viper.GetBool("hcl-provider-block"),
 	}, nil
 }
 
@@ -324,6 +325,9 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolP("interpolate", "", true, "Activate the interpolation for the HCL and the dependencies building for the State file")
 	_ = viper.BindPFlag("interpolate", RootCmd.PersistentFlags().Lookup("interpolate"))
+
+	RootCmd.PersistentFlags().BoolP("hcl-provider-block", "", true, "Generate or not the 'provider {}' block for the imported provider")
+	_ = viper.BindPFlag("hcl-provider-block", RootCmd.PersistentFlags().Lookup("hcl-provider-block"))
 }
 
 func initViper() {

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -65,9 +65,6 @@ func NewWriter(w io.Writer, pv provider.Provider, opts *writer.Options) *Writer 
 			},
 		},
 	}
-	pvcfg := map[string]interface{}{
-		pv.String(): make(map[string]interface{}),
-	}
 	var cat string
 	if opts.HasModule() {
 		cat = writer.ModuleCategoryKey
@@ -85,9 +82,13 @@ func NewWriter(w io.Writer, pv provider.Provider, opts *writer.Options) *Writer 
 		wr.categories = append(wr.categories, cat)
 	}
 	wr.Config[cat]["terraform"] = tfcfg
-	wr.Config[cat]["provider"] = pvcfg
-
-	wr.setProviderConfig(cat)
+	if opts.HCLProviderBlock {
+		pvcfg := map[string]interface{}{
+			pv.String(): make(map[string]interface{}),
+		}
+		wr.Config[cat]["provider"] = pvcfg
+		wr.setProviderConfig(cat)
+	}
 
 	return wr
 }

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -30,7 +30,7 @@ func TestNewHCLWriter(t *testing.T) {
 			"region": "eu-west-1",
 		})
 
-		hw := hcl.NewWriter(nil, p, &writer.Options{})
+		hw := hcl.NewWriter(nil, p, &writer.Options{HCLProviderBlock: true})
 		assert.Equal(t, map[string]map[string]interface{}{
 			"hcl": map[string]interface{}{
 				"provider": map[string]interface{}{
@@ -55,17 +55,36 @@ func TestNewHCLWriter(t *testing.T) {
 			},
 		}, hw.Config)
 	})
+	t.Run("SuccessWithoutProviderBLock", func(t *testing.T) {
+		var (
+			ctrl = gomock.NewController(t)
+			p    = mock.NewProvider(ctrl)
+		)
+		p.EXPECT().String().Return("aws")
+		p.EXPECT().Source().Return("hashicorp/aws")
+
+		hw := hcl.NewWriter(nil, p, &writer.Options{})
+		assert.Equal(t, map[string]map[string]interface{}{
+			"hcl": map[string]interface{}{
+				"resource": map[string]map[string]interface{}{},
+				"terraform": map[string]interface{}{
+					"required_providers": map[string]interface{}{
+						"=tc=aws": map[string]interface{}{
+							"source": "hashicorp/aws",
+						},
+					},
+					"required_version": ">= 1.0",
+				},
+			},
+		}, hw.Config)
+	})
 	t.Run("SuccessWithModule", func(t *testing.T) {
 		var (
 			ctrl = gomock.NewController(t)
 			p    = mock.NewProvider(ctrl)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(nil, p, &writer.Options{Module: "my-module"})
 		assert.Equal(t, map[string]map[string]interface{}{
@@ -75,11 +94,6 @@ func TestNewHCLWriter(t *testing.T) {
 						"source": "./module-my-module",
 					},
 				},
-				"provider": map[string]interface{}{
-					"aws": map[string]interface{}{
-						"region": "${var.region}",
-					},
-				},
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
@@ -87,11 +101,6 @@ func TestNewHCLWriter(t *testing.T) {
 						},
 					},
 					"required_version": ">= 1.0",
-				},
-				"variable": map[string]interface{}{
-					"region": map[string]interface{}{
-						"default": "eu-west-1",
-					},
 				},
 			},
 		}, hw.Config)
@@ -111,12 +120,8 @@ func TestHCLWriter_Write(t *testing.T) {
 		)
 		defer ctrl.Finish()
 
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -132,11 +137,6 @@ func TestHCLWriter_Write(t *testing.T) {
 						},
 					},
 				},
-				"provider": map[string]interface{}{
-					"aws": map[string]interface{}{
-						"region": "${var.region}",
-					},
-				},
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
@@ -144,11 +144,6 @@ func TestHCLWriter_Write(t *testing.T) {
 						},
 					},
 					"required_version": ">= 1.0",
-				},
-				"variable": map[string]interface{}{
-					"region": map[string]interface{}{
-						"default": "eu-west-1",
-					},
 				},
 			},
 		}, hw.Config)
@@ -167,12 +162,9 @@ func TestHCLWriter_Write(t *testing.T) {
 					p    = mock.NewProvider(ctrl)
 				)
 
-				p.EXPECT().String().Return("aws").Times(3)
+				p.EXPECT().String().Return("aws")
 				p.EXPECT().Source().Return("hashicorp/aws")
-				p.EXPECT().TFProvider().Return(aws.Provider())
-				p.EXPECT().Configuration().Return(map[string]interface{}{
-					"region": "eu-west-1",
-				})
+
 				mw = mxwriter.NewMux()
 				hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true, Module: "s"})
 
@@ -188,12 +180,8 @@ func TestHCLWriter_Write(t *testing.T) {
 			p    = mock.NewProvider(ctrl)
 			mw   = mxwriter.NewMux()
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -206,12 +194,8 @@ func TestHCLWriter_Write(t *testing.T) {
 			p    = mock.NewProvider(ctrl)
 			mw   = mxwriter.NewMux()
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -224,12 +208,8 @@ func TestHCLWriter_Write(t *testing.T) {
 			p    = mock.NewProvider(ctrl)
 			mw   = mxwriter.NewMux()
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -248,12 +228,8 @@ func TestHCLWriter_Write(t *testing.T) {
 			p    = mock.NewProvider(ctrl)
 			mw   = mxwriter.NewMux()
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -306,6 +282,48 @@ resource "type" "name" {
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"region": "eu-west-1",
 		})
+
+		hw := hcl.NewWriter(mx, p, &writer.Options{HCLProviderBlock: true, Interpolate: true})
+
+		err := hw.Write("type.name", value)
+		require.NoError(t, err)
+
+		err = hw.Sync()
+		require.NoError(t, err)
+
+		b, err := ioutil.ReadAll(mx)
+		require.NoError(t, err)
+
+		assert.Equal(t, strings.Join(strings.Fields(ehcl), " "), strings.Join(strings.Fields(string(b)), " "))
+	})
+	t.Run("SuccessWithoutProviderBlock", func(t *testing.T) {
+		var (
+			ctrl  = gomock.NewController(t)
+			p     = mock.NewProvider(ctrl)
+			mx    = mxwriter.NewMux()
+			value = map[string]interface{}{
+				"key":         "value",
+				"tc_category": "some-category",
+			}
+			ehcl = `
+terraform {
+	required_providers {
+		aws = {
+			source = "hashicorp/aws"
+		}
+	}
+	required_version = ">= 1.0"
+}
+
+resource "type" "name" {
+  key = "value"
+}
+
+`
+		)
+
+		p.EXPECT().String().Return("aws")
+		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mx, p, &writer.Options{Interpolate: true})
 
@@ -404,7 +422,7 @@ variable "type_name_key" {
 			"region": "eu-west-1",
 		})
 
-		hw := hcl.NewWriter(mx, p, &writer.Options{Interpolate: true, Module: "test"})
+		hw := hcl.NewWriter(mx, p, &writer.Options{Interpolate: true, HCLProviderBlock: true, Module: "test"})
 
 		err := hw.Write("type.name", value)
 		require.NoError(t, err)
@@ -481,7 +499,7 @@ variable "type_name_key" {
 			"region": "eu-west-1",
 		})
 
-		hw := hcl.NewWriter(mx, p, &writer.Options{Interpolate: true, Module: "test", ModuleVariables: map[string]struct{}{"type.key": struct{}{}}})
+		hw := hcl.NewWriter(mx, p, &writer.Options{Interpolate: true, HCLProviderBlock: true, Module: "test", ModuleVariables: map[string]struct{}{"type.key": struct{}{}}})
 
 		err := hw.Write("type.name", value)
 		require.NoError(t, err)
@@ -515,10 +533,6 @@ variable "type_name_key" {
 				},
 			}
 			ehcl = `
-provider "aws" {
-	region = var.region
-}
-
 resource "type" "name" {
   ingress {
 		cidr_blocks = ["0.0.0.0/0"]
@@ -539,18 +553,10 @@ terraform {
 	}
 	required_version = ">= 1.0"
 }
-
-variable "region" {
-	default = "eu-west-1"
-}
 `
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -579,10 +585,6 @@ variable "region" {
 				},
 			}
 			ehcl = `
-provider "aws" {
-	region = var.region
-}
-
 resource "type" "name" {
   ingress {
 		cidr_blocks = []
@@ -598,18 +600,10 @@ terraform {
 	}
 	required_version = ">= 1.0"
 }
-
-variable "region" {
-	default = "eu-west-1"
-}
 `
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -641,10 +635,6 @@ variable "region" {
 				},
 			}
 			ehcl = `
-provider "aws" {
-	region = var.region
-}
-
 resource "type" "name" {
   ingress {
 		cidr_blocks = []
@@ -663,18 +653,10 @@ terraform {
 	}
 	required_version = ">= 1.0"
 }
-
-variable "region" {
-	default = "eu-west-1"
-}
 `
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -705,12 +687,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 		i["to-be-interpolated"] = "${aType.aName.id}"
@@ -740,12 +718,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", Interpolate: true})
 		i["to-be-interpolated"] = "${aType.aName.id}"
@@ -775,12 +749,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", ModuleVariables: map[string]struct{}{"type.name": struct{}{}}, Interpolate: true})
 		i["to-be-interpolated"] = "${aType.aName.id}"
@@ -810,12 +780,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", ModuleVariables: map[string]struct{}{"type.network": struct{}{}}, Interpolate: true})
 		i["to-be-interpolated"] = "${aType.aName.id}"
@@ -846,12 +812,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 		i["to-be-interpolated"] = "${aType.aName.id}"
@@ -882,12 +844,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 		i["a-zone"] = "${aws_instance.instance.availability_zone}"
@@ -921,12 +879,8 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			}
 			i = make(map[string]string)
 		)
-		p.EXPECT().String().Return("aws").Times(3)
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
-		p.EXPECT().TFProvider().Return(aws.Provider())
-		p.EXPECT().Configuration().Return(map[string]interface{}{
-			"region": "eu-west-1",
-		})
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: false})
 		i["should-not-be-interpolated"] = "${aType.aName.id}"

--- a/writer/options.go
+++ b/writer/options.go
@@ -16,6 +16,10 @@ type Options struct {
 	// to use as variables when writing. If empty
 	// means use all attributes as variables
 	ModuleVariables map[string]struct{}
+
+	// HCLProviderBlock make the HCL generate or not the
+	// 'provider "" {}' block
+	HCLProviderBlock bool
 }
 
 // HasModule will check if the Module is empty or not


### PR DESCRIPTION
With also the flag --hcl-provider-block which allows to opt out of the
'provider  {}' block on HCL