### PR TITLE
aws/reader: Now uses the region the user specified to initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Issue with importing `google_storage_bucket_iam_policy`
   ([Issue #258](https://github.com/cycloidio/terracognita/issues/258))
+- Removed default region used on AWS initialization now uses the one specified by the user
+  ([Issue #253](https://github.com/cycloidio/terracognita/issues/253))
 
 ## [0.7.3] _2021-09-23_
 


### PR DESCRIPTION
It was using a default region wich in some cases was causing issues, like in the case of 'govcloud'.

Related to #253 