### PR TITLE
aws: Fixed issue with 'aws_lb_target_group_attachment' raising a panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([Issue #285](https://github.com/cycloidio/terracognita/issues/285))
 - Script to update providers now pushed the tag to the fork
   ([PR #294](https://github.com/cycloidio/terracognita/pull/294))
+- `aws_lb_target_group_attachment` was raising a nil pointer exception
+  ([Issue #297](https://github.com/cycloidio/terracognita/issues/297))
 
 ## [0.7.6] _2022-05-11_
 

--- a/aws/resources.go
+++ b/aws/resources.go
@@ -492,7 +492,7 @@ func albTargetGroupAttachments(ctx context.Context, a *aws, resourceType string,
 		for _, t := range targetHealths {
 			// As this are the required values to get the resource
 			// we validate that they are present
-			if t.Target == nil || i.TargetGroupArn == nil {
+			if t.Target == nil || t.Target.Id == nil || t.Target.Port == nil || i.TargetGroupArn == nil {
 				continue
 			}
 			r, err := initializeResource(a, fmt.Sprintf("%s_%d_%s", *t.Target.Id, *t.Target.Port, *i.TargetGroupArn), resourceType)


### PR DESCRIPTION
Now we validate alll the target values not just the target itself

Closes #297 