### PR TITLE
hcl: allow writing tf/provider separate config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- Allow the writing of tf/provider into a separated config key
+  ([PR#319](https://github.com/cycloidio/terracognita/pull/319))
+
 ## [0.8.1] _2022-08-10_
 
 ### Fixed

--- a/writer/options.go
+++ b/writer/options.go
@@ -20,6 +20,11 @@ type Options struct {
 	// HCLProviderBlock make the HCL generate or not the
 	// 'provider "" {}' block
 	HCLProviderBlock bool
+
+	// TerraformCategoryKey allows to write the Terraform
+	// block containing the required version of the provider
+	// and provider block elsewhere than the module/default file
+	TerraformCategoryKey string
 }
 
 // HasModule will check if the Module is empty or not


### PR DESCRIPTION
The Terraform block and provider can be specified to be written into a
dedicated key, easing the splitting of files when using the library.
This is optional and currently not made available through CLI on
purpose as the need of user/lib consumer are thought to be different.