### PR TITLE
interpolator: Added new entity to deal with the interpolation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Azure: azure: do not define external disk with `azurerm_virtual_machine`
   ([PR #336](https://github.com/cycloidio/terracognita/pull/336))
+- Improved the way resource references/interpolations work, now it's more deterministic
+  ([Issue #346](https://github.com/cycloidio/terracognita/issues/346))
 
 ### Fixed
 

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cycloidio/mxwriter"
 	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/hcl"
+	"github.com/cycloidio/terracognita/interpolator"
 	"github.com/cycloidio/terracognita/mock"
 	"github.com/cycloidio/terracognita/writer"
 	"github.com/golang/mock/gomock"
@@ -860,13 +861,15 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			network = map[string]interface{}{
 				"id": "interpolated",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
-		i["to-be-interpolated"] = "${aType.aName.id}"
+		i.AddResourceAttributes("aType.aName", map[string]string{
+			"id": "to-be-interpolated",
+		})
 		hw.Write("type.name", value)
 		hw.Write("aType.aName", network)
 
@@ -891,13 +894,15 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			network = map[string]interface{}{
 				"id": "interpolated",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", Interpolate: true})
-		i["to-be-interpolated"] = "${aType.aName.id}"
+		i.AddResourceAttributes("aType.aName", map[string]string{
+			"id": "to-be-interpolated",
+		})
 		hw.Write("type.name", value)
 		hw.Write("aType.aName", network)
 
@@ -922,13 +927,15 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			network = map[string]interface{}{
 				"id": "interpolated",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", ModuleVariables: map[string]struct{}{"type.name": struct{}{}}, Interpolate: true})
-		i["to-be-interpolated"] = "${aType.aName.id}"
+		i.AddResourceAttributes("aType.aName", map[string]string{
+			"id": "to-be-interpolated",
+		})
 		hw.Write("type.name", value)
 		hw.Write("aType.aName", network)
 
@@ -953,13 +960,15 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 			network = map[string]interface{}{
 				"id": "interpolated",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", ModuleVariables: map[string]struct{}{"type.network": struct{}{}}, Interpolate: true})
-		i["to-be-interpolated"] = "${aType.aName.id}"
+		i.AddResourceAttributes("aType.aName", map[string]string{
+			"id": "to-be-interpolated",
+		})
 		hw.Write("type.name", value)
 		hw.Write("aType.aName", network)
 
@@ -985,13 +994,15 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 				"id":   "interpolated",
 				"name": "to-be-interpolated",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
-		i["to-be-interpolated"] = "${aType.aName.id}"
+		i.AddResourceAttributes("aType.aName", map[string]string{
+			"id": "to-be-interpolated",
+		})
 		hw.Write("type.name", value)
 		hw.Write("aType.aName", network)
 
@@ -1017,14 +1028,18 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 				"id":                "subnet-1",
 				"availability_zone": "a-zone",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
-		i["a-zone"] = "${aws_instance.instance.availability_zone}"
-		i["1234"] = "${aws_subnet.subnet.id}"
+		i.AddResourceAttributes("aws_instance.instance", map[string]string{
+			"availability_zone": "a-zone",
+		})
+		i.AddResourceAttributes("aws_subnet.subnet", map[string]string{
+			"id": "1234",
+		})
 		hw.Write("aws_subnet.subnet", subnet)
 		hw.Write("aws_instance.instance", instance)
 
@@ -1052,13 +1067,15 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 				"id":   "interpolated",
 				"name": "to-be-interpolated",
 			}
-			i = make(map[string]string)
+			i = interpolator.New("aws")
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: false})
-		i["should-not-be-interpolated"] = "${aType.aName.id}"
+		i.AddResourceAttributes("aType.aName", map[string]string{
+			"id": "should-not-be-interpolated",
+		})
 		hw.Write("type.name", value)
 		hw.Write("aType.aName", network)
 

--- a/interpolator/interpolator.go
+++ b/interpolator/interpolator.go
@@ -1,0 +1,127 @@
+package interpolator
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Interpolator is a helper to interpolate values into attributes, by calling Interpolate
+// it'll try to find which is the best interpolation, if any.
+type Interpolator struct {
+	// provider is the provider prefix used for the specific provider that the interpolator
+	// is gonna be used on
+	provider string
+	// resources is a map with all the resources available to interpolate
+	// the key is the 'aws_instance.front' (KEY+NAME) and the value
+	// is all the attributes it has available to be referenced
+	resources map[string]map[string]map[string]string
+
+	// values holds all the possible values on the resources, the
+	// key is the value itself "123" and the value is the reference
+	// to the resource attribute that has it "${aws_instance.front.id}"
+	// used in case o fallback to check if any attribute has the requested value
+	values map[string]string
+}
+
+// New returns a new intrepolator, expects the provider prefix
+func New(provider string) *Interpolator {
+	return &Interpolator{
+		provider:  provider,
+		resources: make(map[string]map[string]map[string]string),
+		values:    make(map[string]string),
+	}
+}
+
+// AddResourceAttributes adds the resource 'r' (aws_instance.front) with the attributes 'a'
+// to the internal list of resources. If the resource 'r' already exists it'll be replaced
+// with the new set of 'a'
+func (i *Interpolator) AddResourceAttributes(r string, a map[string]string) {
+	sr := strings.Split(r, ".")
+	// This remove the provider from the resource as the reference will never have it
+	// so from 'aws_instance' we transform to 'instance'
+	sr[0] = strings.Join(strings.Split(sr[0], "_")[1:], "_")
+	if _, ok := i.resources[sr[0]]; !ok {
+		i.resources[sr[0]] = make(map[string]map[string]string)
+	}
+	if _, ok := i.resources[sr[0]][sr[1]]; !ok {
+		i.resources[sr[0]][sr[1]] = make(map[string]string)
+	}
+	i.resources[sr[0]][sr[1]] = a
+	for k, v := range a {
+		i.values[v] = fmt.Sprintf("${%s.%s}", r, k)
+	}
+}
+
+// Interpolate will try to return the best interpolation for the attribute 'k' with the value 'v'
+// by trying to match the 'k' with any resource, like 'virtual_machine_id' with a 'virtual_machine' resource
+// which has an attribute with the value 'v'. If none if found the it'll default to check the internal list
+// of all possible 'values'. If nothing is found then it'll return '"", false'
+func (i *Interpolator) Interpolate(k, v string) (string, bool) {
+	sk := strings.Split(k, "_")
+	// We generate a ngram of the k separated by '_', meaning 'virtual_machine_id' will
+	// be ['virtual_machine_id', 'virtual_machine', 'virtual'] this way we try to find
+	// if there is a resource matching from the most possible to the least possible
+	ngramk := make([]string, len(sk), len(sk))
+	for i := range sk {
+		ngramk[len(sk)-(i+1)] = strings.Join(sk[0:i+1], "_")
+	}
+	for ngi, ng := range ngramk {
+		if rns, ok := i.resources[ng]; ok {
+			// We try first to find the exact match
+			at := i.checkAttributes(sk, v, ngi, ng, rns)
+			if at != "" {
+				return at, true
+			}
+		}
+		// If no exact match then we try similar match by using regexp and from all the matching
+		// resources which one is closer. By closer we just sort by length inversed (shortest first)
+		// resources so we know that those have less "differences" from the main key
+		matches := make([]string, 0, 0)
+		for rk := range i.resources {
+			if regexp.MustCompile(fmt.Sprintf("^(.*_)?%s(_.*)?$", ng)).MatchString(rk) {
+				matches = append(matches, rk)
+			}
+		}
+		sort.Slice(matches, func(i, j int) bool {
+			return len(matches[i]) < len(matches[j])
+		})
+		for _, rk := range matches {
+			rns := i.resources[rk]
+			// We try first to find the exact match
+			at := i.checkAttributes(sk, v, ngi, rk, rns)
+			if at != "" {
+				return at, true
+			}
+		}
+	}
+	// If we could not find any precise value then we default to the value list
+	if ref, ok := i.values[v]; ok {
+		return ref, true
+	}
+	return "", false
+}
+
+// checkAttributes will try to find if from the actual list of attribute of the resource there is one matching the expected value.
+// To also be more precise, when iterating over the ngram we try to guess the attribute name by inversing the ngram, so for example
+// if we try to intrapolate 'virtual_machine_id' which will generate ['virtual_machine_id', 'virtual_machine', 'virtual'] once we
+// are on the 'virtual_machine' we try to find the attribute by seeking what's missing on it, in this case the 'id', so we try to
+// match it wit the attribute `.id`
+func (i *Interpolator) checkAttributes(sk []string, v string, ngi int, ng string, rns map[string]map[string]string) string {
+	for rn, attrs := range rns {
+		att := strings.Join(sk[(len(sk)-(ngi)):len(sk)], "_")
+		if av, ok := attrs[att]; ok && av == v {
+			return fmt.Sprintf("${%s.%s.%s}", fmt.Sprintf("%s_%s", i.provider, ng), rn, att)
+		}
+	}
+	// Then if no exact we try to find first one with the same value on the resource
+	for rn, attrs := range rns {
+		for ak, av := range attrs {
+			if av == v {
+				return fmt.Sprintf("${%s.%s.%s}", fmt.Sprintf("%s_%s", i.provider, ng), rn, ak)
+			}
+		}
+	}
+	return ""
+}

--- a/interpolator/interpolator_test.go
+++ b/interpolator/interpolator_test.go
@@ -1,0 +1,39 @@
+package interpolator_test
+
+import (
+	"testing"
+
+	"github.com/cycloidio/terracognita/interpolator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterpolate(t *testing.T) {
+	i := interpolator.New("azurerm")
+	i.AddResourceAttributes("azurerm_virtual_machine.front", map[string]string{
+		"id":    "secretid",
+		"other": "ovalue",
+	})
+	i.AddResourceAttributes("azurerm_virtual_something.front", map[string]string{
+		"id": "secretid",
+	})
+
+	s, ok := i.Interpolate("virtual_machine_id", "secretid")
+	assert.Equal(t, s, "${azurerm_virtual_machine.front.id}")
+	assert.True(t, ok)
+
+	s, ok = i.Interpolate("virtual_machine_potato", "ovalue")
+	assert.Equal(t, s, "${azurerm_virtual_machine.front.other}")
+	assert.True(t, ok)
+
+	s, ok = i.Interpolate("totally_random", "secretid")
+	assert.Equal(t, s, "${azurerm_virtual_something.front.id}")
+	assert.True(t, ok)
+
+	s, ok = i.Interpolate("virtual_id", "secretid")
+	assert.Equal(t, s, "${azurerm_virtual_machine.front.id}")
+	assert.True(t, ok)
+
+	s, ok = i.Interpolate("virtual_machine_potato", "none")
+	assert.Equal(t, s, "")
+	assert.False(t, ok)
+}

--- a/mock/writer.go
+++ b/mock/writer.go
@@ -7,6 +7,7 @@ package mock
 import (
 	reflect "reflect"
 
+	interpolator "github.com/cycloidio/terracognita/interpolator"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -49,7 +50,7 @@ func (mr *WriterMockRecorder) Has(arg0 interface{}) *gomock.Call {
 }
 
 // Interpolate mocks base method.
-func (m *Writer) Interpolate(arg0 map[string]string) {
+func (m *Writer) Interpolate(arg0 *interpolator.Interpolator) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Interpolate", arg0)
 }

--- a/provider/import_test.go
+++ b/provider/import_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cycloidio/terracognita/errcode"
 	"github.com/cycloidio/terracognita/filter"
+	"github.com/cycloidio/terracognita/interpolator"
 	"github.com/cycloidio/terracognita/mock"
 	"github.com/cycloidio/terracognita/provider"
 	"github.com/golang/mock/gomock"
@@ -26,7 +27,7 @@ func TestImport(t *testing.T) {
 			p                 = mock.NewProvider(ctrl)
 			hw                = mock.NewWriter(ctrl)
 			sw                = mock.NewWriter(ctrl)
-			i                 = make(map[string]string)
+			i                 = interpolator.New("aws")
 			instanceResource1 = mock.NewResource(ctrl)
 			instanceResource2 = mock.NewResource(ctrl)
 			iamUser1          = mock.NewResource(ctrl)
@@ -37,6 +38,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_instance", f).Return([]provider.Resource{instanceResource1, instanceResource2}, nil)
@@ -95,7 +97,7 @@ func TestImport(t *testing.T) {
 			sw                = mock.NewWriter(ctrl)
 			instanceResource1 = mock.NewResource(ctrl)
 			instanceResource2 = mock.NewResource(ctrl)
-			i                 = make(map[string]string)
+			i                 = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Include: []string{"aws_instance"},
@@ -104,6 +106,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().Resources(ctx, "aws_instance", f).Return([]provider.Resource{instanceResource1, instanceResource2}, nil)
 
@@ -146,7 +149,7 @@ func TestImport(t *testing.T) {
 			sw       = mock.NewWriter(ctrl)
 			iamUser1 = mock.NewResource(ctrl)
 			iamUser2 = mock.NewResource(ctrl)
-			i        = make(map[string]string)
+			i        = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Exclude: []string{"aws_instance"},
@@ -155,6 +158,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
@@ -199,7 +203,7 @@ func TestImport(t *testing.T) {
 			sw       = mock.NewWriter(ctrl)
 			iamUser1 = mock.NewResource(ctrl)
 			iamUser2 = mock.NewResource(ctrl)
-			i        = make(map[string]string)
+			i        = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Exclude: []string{"aws_instance"},
@@ -208,6 +212,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
@@ -248,7 +253,7 @@ func TestImport(t *testing.T) {
 			sw       = mock.NewWriter(ctrl)
 			iamUser1 = mock.NewResource(ctrl)
 			iamUser2 = mock.NewResource(ctrl)
-			i        = make(map[string]string)
+			i        = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Exclude: []string{"aws_instance"},
@@ -257,6 +262,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
@@ -292,7 +298,7 @@ func TestImport(t *testing.T) {
 			hw       = mock.NewWriter(ctrl)
 			iamUser1 = mock.NewResource(ctrl)
 			iamUser2 = mock.NewResource(ctrl)
-			i        = make(map[string]string)
+			i        = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Exclude: []string{"aws_instance"},
@@ -301,6 +307,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
@@ -337,7 +344,7 @@ func TestImport(t *testing.T) {
 			sw       = mock.NewWriter(ctrl)
 			iamUser1 = mock.NewResource(ctrl)
 			iamUser2 = mock.NewResource(ctrl)
-			i        = make(map[string]string)
+			i        = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Exclude: []string{"aws_instance"},
@@ -346,6 +353,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
@@ -386,7 +394,7 @@ func TestImport(t *testing.T) {
 			sw       = mock.NewWriter(ctrl)
 			iamUser1 = mock.NewResource(ctrl)
 			iamUser2 = mock.NewResource(ctrl)
-			i        = make(map[string]string)
+			i        = interpolator.New("aws")
 
 			f = &filter.Filter{
 				Exclude: []string{"aws_instance"},
@@ -395,6 +403,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
@@ -490,6 +499,7 @@ func TestImport(t *testing.T) {
 		p.EXPECT().HasResourceType("aws_instance").Return(true)
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().Resources(ctx, "aws_iam_user", f).Return(nil, errors.New("should stop the import"))
 
 		err := provider.Import(ctx, p, hw, sw, f, ioutil.Discard)
@@ -503,7 +513,7 @@ func TestImport(t *testing.T) {
 			p                 = mock.NewProvider(ctrl)
 			hw                = mock.NewWriter(ctrl)
 			sw                = mock.NewWriter(ctrl)
-			i                 = make(map[string]string)
+			i                 = interpolator.New("aws")
 			instanceResource1 = mock.NewResource(ctrl)
 			instanceResource2 = mock.NewResource(ctrl)
 
@@ -512,6 +522,7 @@ func TestImport(t *testing.T) {
 
 		defer ctrl.Finish()
 
+		p.EXPECT().String().Return("aws")
 		p.EXPECT().ResourceTypes().Return([]string{"aws_instance", "aws_iam_user"})
 
 		p.EXPECT().Resources(ctx, "aws_instance", f).Return([]provider.Resource{instanceResource1, instanceResource2}, nil)

--- a/state/writer.go
+++ b/state/writer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/cycloidio/terracognita/errcode"
+	"github.com/cycloidio/terracognita/interpolator"
 	"github.com/cycloidio/terracognita/log"
 	"github.com/cycloidio/terracognita/provider"
 	"github.com/cycloidio/terracognita/util"
@@ -134,8 +135,8 @@ func (w *Writer) Sync() error {
 }
 
 // Interpolate will defined dependencies for each component using
-// the `i` map built in the import.
-func (w *Writer) Interpolate(i map[string]string) {
+// the `i` Interpolator built in the import.
+func (w *Writer) Interpolate(i *interpolator.Interpolator) {
 	if !w.opts.Interpolate {
 		return
 	}
@@ -160,10 +161,10 @@ func (w *Writer) Interpolate(i map[string]string) {
 			if !ok {
 				continue
 			}
-			for _, attribute := range res.InstanceState().Attributes {
+			for ak, av := range res.InstanceState().Attributes {
 				// if we find any relevant link between the instance attribute and the interpolation map,
 				// we flag a dependency
-				if dependency, ok := i[attribute]; ok {
+				if dependency, ok := i.Interpolate(ak, av); ok {
 					rt, rn := extractResourceTypeAndName(dependency)
 					rsc := fmt.Sprintf("%s.%s", rt, rn)
 					// avoid mutual dependencies

--- a/state/writer_test.go
+++ b/state/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cycloidio/terracognita/errcode"
+	"github.com/cycloidio/terracognita/interpolator"
 	"github.com/cycloidio/terracognita/mock"
 	"github.com/cycloidio/terracognita/provider"
 	"github.com/cycloidio/terracognita/state"
@@ -308,7 +309,7 @@ func TestSync(t *testing.T) {
 func TestDependencies(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
-			i      = make(map[string]string)
+			i      = interpolator.New("aws")
 			ctrl   = gomock.NewController(t)
 			b      = &bytes.Buffer{}
 			sw     = state.NewWriter(b, &writer.Options{Interpolate: true})
@@ -433,7 +434,9 @@ func TestDependencies(t *testing.T) {
 		err = sw.Write("aws_security_group_rule.sgrule", resSGR)
 		require.NoError(t, err)
 
-		i["sg-1234"] = "${aws_security_group.sg.id}"
+		i.AddResourceAttributes("aws_security_group.sg", map[string]string{
+			"id": "sg-1234",
+		})
 		sw.Interpolate(i)
 
 		err = sw.Sync()
@@ -453,7 +456,7 @@ func TestDependencies(t *testing.T) {
 	})
 	t.Run("SuccessWitmModules", func(t *testing.T) {
 		var (
-			i      = make(map[string]string)
+			i      = interpolator.New("aws")
 			ctrl   = gomock.NewController(t)
 			b      = &bytes.Buffer{}
 			sw     = state.NewWriter(b, &writer.Options{Interpolate: true, Module: "cycloid"})
@@ -580,7 +583,9 @@ func TestDependencies(t *testing.T) {
 		err = sw.Write("aws_security_group_rule.sgrule", resSGR)
 		require.NoError(t, err)
 
-		i["sg-1234"] = "${aws_security_group.sg.id}"
+		i.AddResourceAttributes("aws_security_group.sg", map[string]string{
+			"id": "sg-1234",
+		})
 		sw.Interpolate(i)
 
 		err = sw.Sync()
@@ -600,7 +605,7 @@ func TestDependencies(t *testing.T) {
 	})
 	t.Run("SuccessNoInterpolation", func(t *testing.T) {
 		var (
-			i      = make(map[string]string)
+			i      = interpolator.New("aws")
 			ctrl   = gomock.NewController(t)
 			b      = &bytes.Buffer{}
 			sw     = state.NewWriter(b, &writer.Options{Interpolate: false})
@@ -713,7 +718,9 @@ func TestDependencies(t *testing.T) {
 		err = sw.Write("aws_security_group_rule.sgrule", resSGR)
 		require.NoError(t, err)
 
-		i["sg-1234"] = "${aws_security_group.sg.id}"
+		i.AddResourceAttributes("aws_security_group.sg", map[string]string{
+			"id": "sg-1234",
+		})
 		sw.Interpolate(i)
 
 		err = sw.Sync()

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,5 +1,7 @@
 package writer
 
+import "github.com/cycloidio/terracognita/interpolator"
+
 //go:generate mockgen -destination=../mock/writer.go -mock_names=Writer=Writer -package mock github.com/cycloidio/terracognita/writer Writer
 
 const (
@@ -35,5 +37,5 @@ type Writer interface {
 
 	// Interpolate replaces the hardcoded resources link
 	// with TF interpolation
-	Interpolate(map[string]string)
+	Interpolate(*interpolator.Interpolator)
 }


### PR DESCRIPTION
This entity hides all the abstraction in terms of choosing which resource+attribute is best based on all the resources stored in it.

It'll try different ways to match the resource and the attribute and the value but the end fallback will be the one we had before, to just match any equal value to the expected value without taking into consideration the actual attribute

Closes #346 