### PR TITLE
azurerm: fix #352 admin_password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+- Azure: Set a valide `admin_password` with `azurerm_windows_virtual_machine`
+  ([Issue #352](https://github.com/cycloidio/terracognita/issues/352))
 - Azure: azure: do not define external disk with `azurerm_virtual_machine`
   ([PR #336](https://github.com/cycloidio/terracognita/pull/336))
 

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -177,6 +177,13 @@ func (a *azurerm) FixResource(t string, v cty.Value) (cty.Value, error) {
 			if len(path) == 3 {
 				if gas, ok := path[0].(cty.GetAttrStep); ok {
 					switch gas.Name {
+					case "os_profile":
+						switch path[2].(cty.GetAttrStep).Name {
+						case "admin_password":
+							// The value can't be retrieved. Terraform Azure provider set "ignored-as-imported" which is not a valid password.
+							// In this case, set the default password which respects Azure constraints
+							return cty.StringVal("Ignored-as-!mport3d"), nil
+						}
 					case "storage_os_disk":
 						var idx int
 						err := gocty.FromCtyValue(path[1].(cty.IndexStep).Key, &idx)
@@ -249,6 +256,10 @@ func (a *azurerm) FixResource(t string, v cty.Value) (cty.Value, error) {
 			if len(path) > 0 {
 				if gas, ok := path[0].(cty.GetAttrStep); ok {
 					switch gas.Name {
+					case "admin_password":
+						// The value can't be retrieved. Terraform Azure provider set "ignored-as-imported" which is not a valid password.
+						// In this case, set the default password which respects Azure constraints
+						return cty.StringVal("Ignored-as-!mport3d"), nil
 					case "platform_fault_domain":
 						// By default this attribute is set, but this is not a valid value with terraform apply.
 						// In this case, we shouldn't write platform_fault_domain.


### PR DESCRIPTION
The value can't be retrieved. Terraform Azure provider set "ignored-as-imported" which is not a valid password. In this case, set the default password wich respects Azure constraints