### PR TITLE
provider/resource: Added support for 'ExactlyOneOf' schema option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([Issue #361](https://github.com/cycloidio/terracognita/issues/361))
 - Ability declare module variables on map types
   ([Issue #365](https://github.com/cycloidio/terracognita/issues/365))
+- Support for `ExactlyOneOf` configuration for the schema so the generated HCL is correct
+  ([Issue #340](https://github.com/cycloidio/terracognita/issues/340))
 
 ### Changed
 

--- a/aws/reader/connector.go
+++ b/aws/reader/connector.go
@@ -59,14 +59,14 @@ import (
 //
 // The accountID is helpful to return only the AMI or snapshots that belong to the account.
 //
-// While the region has to be a valid AWS region
+// # While the region has to be a valid AWS region
 //
 // An error is returned if any of the needed AWS request for creating the reader returns an AWS error, in such case it
 // will have any of the common error codes (see below) or EmptyStaticCreds code or a go standard error in case that no
 // regions are matched with the ones available, at the time, in AWS.
 // See:
-//  * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors
-//  * https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
+//   - https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors
+//   - https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
 func New(ctx context.Context, accessKey, secretKey, region, sessionToken string, config *aws.Config) (Reader, error) {
 	var c = connector{}
 


### PR DESCRIPTION
So we do not generate wrong HCL by dismissing this configuration

Closes #340 