### PR TITLE
provider/resource: Nested HCL maps now are written correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 - Added new Azure resource: `azurerm_api_management`
   ([PR#363](https://github.com/cycloidio/terracognita/pull/363))
 
+### Fixed
+
+- Nested HCL Maps now are written correctly
+  ([Issue #337](https://github.com/cycloidio/terracognita/issues/337))
+
 ## [0.8.3] _2023-03-14_
 
 ### Fixed

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -642,6 +642,10 @@ func normalizeSetList(sch map[string]*schema.Schema, list []interface{}) interfa
 					if !isDefault(sch[k], ns) {
 						res[k] = ns
 					}
+				case map[string]interface{}:
+					if !isDefault(sch[k], v) {
+						res[fmt.Sprintf("=tc=%s", k)] = v
+					}
 				case interface{}:
 					if !isDefault(sch[k], v) {
 						res[k] = v


### PR DESCRIPTION
Before they where writtin without the '=' which was making it fail

Closes #337 