### PR TITLE
provider: Added 'Version' to the Provider interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Azurerm added new resource: `azurerm_network_interface_security_group_association`
   ([Issue #389](https://github.com/cycloidio/terracognita/issues/389))
 
+### Fixed
+- The generated HCL now has the fixed version for the provider used instead of using the latest one by default
+  ([Issue #378](https://github.com/cycloidio/terracognita/issues/378))
+
 
 ## [0.8.4] _2023-05-18_
 

--- a/Makefile
+++ b/Makefile
@@ -97,4 +97,4 @@ clean: ## Removes binary and/or docker image
 
 .PHONY: update-terraform-provider
 update-terraform-provider: ## Update terraform-provider version used for AWS, Azure, GCP
-	./scripts/terraform-provider-update/update.sh $(PROVIDER) $(VERSION)
+	./scripts/terraform-provider-update/update.sh $(PROVIDER)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -20,6 +20,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// version of the Terraform provider, this is automatically changed with the 'make update-terraform-provider'
+const version = "4.9.0"
+
 // skippableCodes is a list of codes
 // which won't make Terracognita failed
 // but they will be printed on the output
@@ -128,6 +131,7 @@ func (a *aws) HasResourceType(t string) bool {
 	return err == nil
 }
 func (a *aws) Source() string                        { return "hashicorp/aws" }
+func (a *aws) Version() string                       { return version }
 func (a *aws) Configuration() map[string]interface{} { return a.configuration }
 func (a *aws) FixResource(t string, v cty.Value) (cty.Value, error) {
 	var err error

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -22,6 +22,9 @@ import (
 	"github.com/cycloidio/terracognita/provider"
 )
 
+// version of the Terraform provider, this is automatically changed with the 'make update-terraform-provider'
+const version = "3.20.0"
+
 // skippableCodes is a list of codes
 // which won't make Terracognita failed
 // but they will be printed on the output
@@ -88,6 +91,7 @@ func (a *azurerm) Region() string                        { return a.azurerReader
 func (a *azurerm) String() string                        { return "azurerm" }
 func (a *azurerm) TagKey() string                        { return "tags" }
 func (a *azurerm) Source() string                        { return "hashicorp/azurerm" }
+func (a *azurerm) Version() string                       { return version }
 func (a *azurerm) Configuration() map[string]interface{} { return a.configuraiton }
 
 func (a *azurerm) ResourceTypes() []string {

--- a/google/provider.go
+++ b/google/provider.go
@@ -18,6 +18,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// version of the Terraform provider, this is automatically changed with the 'make update-terraform-provider'
+const version = "4.9.0"
+
 // skippableCodes is a list of codes
 // which won't make Terracognita failed
 // but they will be printed on the output
@@ -76,6 +79,7 @@ func (g *google) Project() string                       { return g.tfGoogleClien
 func (g *google) String() string                        { return "google" }
 func (g *google) TagKey() string                        { return "labels" }
 func (g *google) Source() string                        { return "hashicorp/google" }
+func (g *google) Version() string                       { return version }
 func (g *google) Configuration() map[string]interface{} { return make(map[string]interface{}) }
 
 func (g *google) ResourceTypes() []string {

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -63,7 +63,8 @@ func NewWriter(w io.Writer, pv provider.Provider, opts *writer.Options) *Writer 
 			// just '{' so this would be included too and it would
 			// be invalid configuration
 			fmt.Sprintf("=tc=%s", pv.String()): map[string]interface{}{
-				"source": pv.Source(),
+				"source":  pv.Source(),
+				"version": fmt.Sprintf("=%s", pv.Version()),
 			},
 		},
 	}

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -28,6 +28,7 @@ func TestNewHCLWriter(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws").Times(2)
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"region": "eu-west-1",
@@ -41,7 +42,8 @@ func TestNewHCLWriter(t *testing.T) {
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
-							"source": "hashicorp/aws",
+							"source":  "hashicorp/aws",
+							"version": "=4.9.0",
 						},
 					},
 					"required_version": ">= 1.0",
@@ -56,6 +58,7 @@ func TestNewHCLWriter(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws").Times(2)
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"region": "eu-west-1",
@@ -75,7 +78,8 @@ func TestNewHCLWriter(t *testing.T) {
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
-							"source": "hashicorp/aws",
+							"source":  "hashicorp/aws",
+							"version": "=4.9.0",
 						},
 					},
 					"required_version": ">= 1.0",
@@ -90,6 +94,7 @@ func TestNewHCLWriter(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(nil, p, &writer.Options{})
 		assert.Equal(t, map[string]map[string]interface{}{
@@ -98,7 +103,8 @@ func TestNewHCLWriter(t *testing.T) {
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
-							"source": "hashicorp/aws",
+							"source":  "hashicorp/aws",
+							"version": "=4.9.0",
 						},
 					},
 					"required_version": ">= 1.0",
@@ -113,6 +119,7 @@ func TestNewHCLWriter(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(nil, p, &writer.Options{Module: "my-module"})
 		assert.Equal(t, map[string]map[string]interface{}{
@@ -125,7 +132,8 @@ func TestNewHCLWriter(t *testing.T) {
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
-							"source": "hashicorp/aws",
+							"source":  "hashicorp/aws",
+							"version": "=4.9.0",
 						},
 					},
 					"required_version": ">= 1.0",
@@ -140,6 +148,7 @@ func TestNewHCLWriter(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(nil, p, &writer.Options{
 			Module:               "my-module",
@@ -157,7 +166,8 @@ func TestNewHCLWriter(t *testing.T) {
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
-							"source": "hashicorp/aws",
+							"source":  "hashicorp/aws",
+							"version": "=4.9.0",
 						},
 					},
 					"required_version": ">= 1.0",
@@ -182,6 +192,7 @@ func TestHCLWriter_Write(t *testing.T) {
 
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -200,7 +211,8 @@ func TestHCLWriter_Write(t *testing.T) {
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
 						"=tc=aws": map[string]interface{}{
-							"source": "hashicorp/aws",
+							"source":  "hashicorp/aws",
+							"version": "=4.9.0",
 						},
 					},
 					"required_version": ">= 1.0",
@@ -224,6 +236,7 @@ func TestHCLWriter_Write(t *testing.T) {
 
 				p.EXPECT().String().Return("aws")
 				p.EXPECT().Source().Return("hashicorp/aws")
+				p.EXPECT().Version().Return("4.9.0")
 
 				mw = mxwriter.NewMux()
 				hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true, Module: "s"})
@@ -242,6 +255,7 @@ func TestHCLWriter_Write(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -256,6 +270,7 @@ func TestHCLWriter_Write(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -270,6 +285,7 @@ func TestHCLWriter_Write(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -290,6 +306,7 @@ func TestHCLWriter_Write(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -318,6 +335,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -332,6 +350,7 @@ resource "type" "name" {
 
 		p.EXPECT().String().Return("aws").Times(2)
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"region": "eu-west-1",
@@ -364,6 +383,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -378,6 +398,7 @@ resource "type" "name" {
 
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mx, p, &writer.Options{Interpolate: true})
 
@@ -455,6 +476,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -491,6 +513,7 @@ variable "type_name_key" {
 		)
 		p.EXPECT().String().Return("aws").Times(2)
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"region": "eu-west-1",
@@ -576,6 +599,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -610,6 +634,7 @@ variable "type_name_tags" {
 		)
 		p.EXPECT().String().Return("aws").Times(2)
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"region": "eu-west-1",
@@ -664,6 +689,7 @@ terraform {
 	required_providers {
 		azurerm = {
 			source = "hashicorp/azurerm"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -687,6 +713,7 @@ variable "type_name_key" {
 		)
 		p.EXPECT().String().Return("azurerm").Times(5)
 		p.EXPECT().Source().Return("hashicorp/azurerm")
+		p.EXPECT().Version().Return("4.9.0")
 		p.EXPECT().TFProvider().Return(azurerm.AzureProvider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
 			"metadata_host": "host",
@@ -739,6 +766,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -747,6 +775,7 @@ terraform {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -786,6 +815,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -794,6 +824,7 @@ terraform {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -839,6 +870,7 @@ terraform {
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"
+			version = "=4.9.0"
 		}
 	}
 	required_version = ">= 1.0"
@@ -847,6 +879,7 @@ terraform {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 
@@ -879,6 +912,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 		i.AddResourceAttributes("aType.aName", map[string]string{
@@ -912,6 +946,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", Interpolate: true})
 		i.AddResourceAttributes("aType.aName", map[string]string{
@@ -945,6 +980,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", ModuleVariables: map[string]struct{}{"type.name": struct{}{}}, Interpolate: true})
 		i.AddResourceAttributes("aType.aName", map[string]string{
@@ -978,6 +1014,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Module: "test", ModuleVariables: map[string]struct{}{"type.network": struct{}{}}, Interpolate: true})
 		i.AddResourceAttributes("aType.aName", map[string]string{
@@ -1012,6 +1049,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 		i.AddResourceAttributes("aType.aName", map[string]string{
@@ -1046,6 +1084,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: true})
 		i.AddResourceAttributes("aws_instance.instance", map[string]string{
@@ -1085,6 +1124,7 @@ func TestHCLWriter_Interpolate(t *testing.T) {
 		)
 		p.EXPECT().String().Return("aws")
 		p.EXPECT().Source().Return("hashicorp/aws")
+		p.EXPECT().Version().Return("4.9.0")
 
 		hw := hcl.NewWriter(mw, p, &writer.Options{Interpolate: false})
 		i.AddResourceAttributes("aType.aName", map[string]string{

--- a/mock/provider.go
+++ b/mock/provider.go
@@ -207,3 +207,17 @@ func (mr *ProviderMockRecorder) TagKey() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagKey", reflect.TypeOf((*Provider)(nil).TagKey))
 }
+
+// Version mocks base method.
+func (m *Provider) Version() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Version indicates an expected call of Version.
+func (mr *ProviderMockRecorder) Version() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*Provider)(nil).Version))
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -48,6 +48,9 @@ type Provider interface {
 	// to declare on the HCL
 	Source() string
 
+	// Version returns the current version of the used provider
+	Version() string
+
 	// Configuration returns the Provider configuration
 	// that may be interpolated with HCL when declaring
 	// the provider. The keys have to be the Provider

--- a/scripts/terraform-provider-update/README.md
+++ b/scripts/terraform-provider-update/README.md
@@ -5,6 +5,7 @@
 Script used by `make update-terraform-provider`.
 The goal is to help updating Terraform and Terraform providers used by Terracognita.
 
+The firs parameter is the `provider` to update and it can also expect the `TAG` env variable import a specific version
 
 ### Actions
 
@@ -23,3 +24,4 @@ update_terracognita
  * Update Terracognita Go mod with the latest
  * Update README.md
  * Apply specific `terracognita_fix_*` script (if needed)
+ * Update the specific version on the provider package

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -16,6 +16,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// version of the Terraform provider, this is automatically changed with the 'make update-terraform-provider'
+const version = "2.2.0"
+
 type vsphere struct {
 	tfVSphereClient interface{}
 	tfProvider      *schema.Provider
@@ -113,7 +116,8 @@ func (vs vsphere) Resources(ctx context.Context, resourceType string, f *filter.
 	return resources, nil
 }
 
-func (vs vsphere) Source() string { return "hashicorp/vsphere" }
+func (vs vsphere) Source() string  { return "hashicorp/vsphere" }
+func (vs vsphere) Version() string { return version }
 
 func (vs vsphere) Configuration() map[string]interface{}                { return vs.configuration }
 func (vs vsphere) FixResource(t string, v cty.Value) (cty.Value, error) { return v, nil }


### PR DESCRIPTION
Now each provider will have to specify to which version they are importing, this way we can later on set this version to the provider configuration on the HCL. This way we prevent compatibility issues between provider versions

Closes #378, closes #374, closes #392