### PR TITLE
azurerm: fix dropped error

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -317,6 +317,9 @@ func (a *azurerm) FixResource(t string, v cty.Value) (cty.Value, error) {
 			}
 			return v, nil
 		})
+		if err != nil {
+			return v, errors.Wrapf(err, "failed to convert CTY value to GO type")
+		}
 	case "azurerm_network_security_group":
 		v, err = cty.Transform(v, func(path cty.Path, v cty.Value) (cty.Value, error) {
 			if len(path) > 0 {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `azurerm` package.